### PR TITLE
Github Releases for Windows/Mac/Linux AMD64

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,10 +46,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-  
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest,windows-latest,macos-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -64,3 +66,24 @@ jobs:
         with:
           command: build
           args: --release
+      - name: Rename (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cp target/release/gfold ./gfold-linux-amd64
+      - name: Rename (MacOS)
+        if: runner.os == 'MacOS'
+        run: |
+          cp target/release/gfold ./gfold-macos-amd64
+      - name: Rename (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Copy-Item target\release\gfold.exe gfold-windows-amd64.exe
+      - name: Github Release
+        if: github.actor == 'nickgerace'
+        uses: ncipollo/release-action@v1.6.1
+        with:
+          tag: ${{ github.run_number }}
+          artifacts: "gfold*"
+          allowUpdates: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
+            


### PR DESCRIPTION
For every successful build it will create a release # which is the CI run # and put all the binaries under there for that run. Docker arm64 builds were slow so I removed that idea. armv7 didn't work because of Clap.
![image](https://user-images.githubusercontent.com/1342149/78950372-90bcca80-7a9c-11ea-9045-e5a5590a5a56.png)
