### PR TITLE
Skip bare repositories during status fetching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,13 @@
 MAKEPATH:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 NAME:=gfold
 
-cargo-tree:
+run:
+	@cd $(MAKEPATH); cargo fmt
+	@cd $(MAKEPATH); cargo run -- -p ..
+
+tree:
 	cd $(MAKEPATH); cargo tree
 
-build-static:
+static:
 	docker pull clux/muslrust
 	cd $(MAKEPATH); docker run -v $(MAKEPATH):/volume --rm -t clux/muslrust cargo build


### PR DESCRIPTION
Add error handling for bare repositories. This is a fix to GitHub issue 11. During status fetching
for a given repository object, we will "continue" to the next repository object if the current
object is bare.