### PR TITLE
Update README to reflect release build availability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfold"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Nick Gerace <nickagerace@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -27,17 +27,13 @@ While this tool might seem limited in scope and purpose, that is by design.
 Features, such as recursive search and async-await support, are future goals.
 This application aims to do one or few things well.
 
-One more thing: doing one or few things well includes not only the usual Linux/macOS amd64 users, but users from multiple major platforms and architectures.
-
 ## Installation
 
-While there are no release builds at the moment, you can build and install ```gfold``` by executing the following.
+You can download a [release](https://github.com/nickgerace/gfold/releases), or you can build and install ```gfold``` by executing the following.
 
 ```bash
 cargo install --git https://github.com/nickgerace/gfold
 ```
-
-**Note**: There is now an experimental release build for Linux amd64. It's a statically linked binary using MUSL.
 
 ## Usage
 
@@ -47,23 +43,28 @@ There's only two usage options at the moment (CWD or specified path), but you ca
 gfold --help
 ```
 
+Here are some example invocations...
+
+```bash
+gfold
+gfold -p ..
+gfold -p $HOME
+```
+
 ## Compatibility
 
-```gfold``` should work on Linux, macOS, and Windows.
+```gfold``` should work on Linux amd64, macOS amd64, and Windows amd64.
 All external crates were vetted for multi-platform (including Windows 10) support.
-
-The CI/CD pipeline currently only tests Ubuntu amd64 builds, but this is subject to change.
-While not officially tested in a GitHub Action, its worth noting that the application is developed natively on a Windows 10 amd64 machine.
 
 ## Future Plans
 
 - Add recursive function to search sub-directories.
 - Replace sequential functions with async-await.
-- Add installation instructions with releases available.
+- Add better error handling for edge cases (i.e. bare repositories).
 - Add version checking, using the GitHub API ([example: bat](https://api.github.com/repos/sharkdp/bat/releases/latest)), to compare the latest tag with Clap's local version.
 
 ## Additional Information
 
 - Author: [Nick Gerace](https://nickgerace.dev)
-- [Contributors](https://github.com/nickgerace/gfold/graphs/contributors)
+- Contributors: [graph](https://github.com/nickgerace/gfold/graphs/contributors)
 - License: MIT

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use gfold::walk_dir;
 
 fn main() {
     let matches = App::new("gfold")
-        .version("0.2.1")
+        .version("0.2.2")
         .about(
             "https://github.com/nickgerace/gfold\n\n\
             This application helps your organize multiple Git repositories via CLI.\n\


### PR DESCRIPTION
Since release builds are now available for all major desktop OSes on
amd64, the README needs to reflect this. Also, fix some misc readability
and grammatical errors.