### PR TITLE
 Upgrade to v0.3.0, and use match guards to print bare repository status to STDOUT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 # Visual studio
 .vs/*
 .vscode/*
+
+# macOS
+**/.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfold"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Nick Gerace <nickagerace@gmail.com>"]
 edition = "2018"
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,16 @@
 
 MAKEPATH:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 NAME:=gfold
+VERSION:=0.3.0
 
-run:
-	@cd $(MAKEPATH); cargo fmt
+run: fmt
 	@cd $(MAKEPATH); cargo run -- -p ..
+
+build: fmt
+	@cd $(MAKEPATH); cargo build
+
+fmt:
+	@cd $(MAKEPATH); cargo fmt
 
 tree:
 	cd $(MAKEPATH); cargo tree
@@ -17,3 +23,6 @@ tree:
 static:
 	docker pull clux/muslrust
 	cd $(MAKEPATH); docker run -v $(MAKEPATH):/volume --rm -t clux/muslrust cargo build --release
+
+version:
+	grep -r --exclude-dir=target $(VERSION) $(MAKEPATH)

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ tree:
 
 static:
 	docker pull clux/muslrust
-	cd $(MAKEPATH); docker run -v $(MAKEPATH):/volume --rm -t clux/muslrust cargo build
+	cd $(MAKEPATH); docker run -v $(MAKEPATH):/volume --rm -t clux/muslrust cargo build --release

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 ```gfold``` is a CLI application that helps you keep track of multiple Git repositories.
 
 ```bash
-nick at hostname in ~/git
+user at hostname in ~/git
 % gfold
 bat         clean    master  git@github.com:sharkdp/bat.git
+bare-repo   bare     dev     https://github.com/<user>/bare-repo.git
 exa         clean    master  git@github.com:ogham/exa.git
-gfold       unclean  master  git@github.com:nickgerace/gfold.git
-nushell     clean    master  git@github.com:nushell/nushell.git
+gfold       unclean  async   git@github.com:nickgerace/gfold.git
+nushell     clean    master  https://github.com/nushell/nushell.git
 tockilator  clean    master  git@github.com:oxidecomputer/tockilator.git
 ```
 
@@ -29,11 +30,13 @@ This application aims to do one or few things well.
 
 ## Installation
 
-You can download a [release](https://github.com/nickgerace/gfold/releases), or you can build and install ```gfold``` by executing the following.
+The recommended method to install ```gfold``` is by executing the following...
 
 ```bash
 cargo install --git https://github.com/nickgerace/gfold
 ```
+
+There may be some [releases](https://github.com/nickgerace/gfold/releases) available, but there is not a consistent, CI/CD pipeline for this tool yet.
 
 ## Usage
 
@@ -53,18 +56,22 @@ gfold -p $HOME
 
 ## Compatibility
 
-```gfold``` should work on Linux amd64, macOS amd64, and Windows amd64.
 All external crates were vetted for multi-platform (including Windows 10) support.
+```gfold``` is tested for the following systems, but may work on more...
+
+- Linux amd64 (default, dynamically linked)
+- Linux amd64 (MUSL, statically linked)
+- macOS amd64
+- Windows 10 amd64
 
 ## Future Plans
 
 - Add recursive function to search sub-directories.
 - Replace sequential functions with async-await.
-- Add better error handling for edge cases (i.e. bare repositories).
 - Add version checking, using the GitHub API ([example: bat](https://api.github.com/repos/sharkdp/bat/releases/latest)), to compare the latest tag with Clap's local version.
 
 ## Additional Information
 
 - Author: [Nick Gerace](https://nickgerace.dev)
-- Contributors: [graph](https://github.com/nickgerace/gfold/graphs/contributors)
-- License: MIT
+- Contributors: [Graph](https://github.com/nickgerace/gfold/graphs/contributors)
+- License: [MIT](https://github.com/nickgerace/gfold/blob/master/LICENSE)

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use gfold::walk_dir;
 
 fn main() {
     let matches = App::new("gfold")
-        .version("0.2.2")
+        .version("0.3.0")
         .about(
             "https://github.com/nickgerace/gfold\n\n\
             This application helps your organize multiple Git repositories via CLI.\n\


### PR DESCRIPTION
When a repository object returns a BareRepo ErrorCode for its statuses,
we now use the Option type to help print the result to STDOUT. This
changes the previous behavior, which was to just "continue" the loop.

Increment SemVer minor version to align with the new BareRepo STDOUT
feature.