### PR TITLE
Add tags automation to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ test:
 tree:
 	cd $(MAKEPATH); cargo tree
 
+tag:
+	cd $(MAKEPATH); git tag $(VERSION)
+	cd $(MAKEPATH); git push --tags origin master
+
 grep-version:
 	@cd $(MAKEPATH); grep -r \
 		--exclude-dir={target,.git} \


### PR DESCRIPTION
Add Make target for tagging at a specific SemVer. This tag is then
pushed to the main branch.