### PR TITLE
Add slimmer build and remove MUSL mentions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,8 +2,8 @@ on: [push]
 name: gfold actions
 jobs:
 
-  check:
-    name: Check
+  pre-build:
+    name: Pre-Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -15,37 +15,25 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-      - name: Run cargo check
+      - name: cargo check
         uses: actions-rs/cargo@v1
         with:
           command: check
-      - name: Run cargo fmt
+      - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-      - name: Run cargo clippy
+      - name: cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Run cargo test
+      - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # macOS
 **/.DS_Store
+
+# IDEs
+.idea/

--- a/README.md
+++ b/README.md
@@ -69,13 +69,12 @@ gfold -r $HOME/repositories
 
 ## Compatibility
 
-All external crates were vetted for multi-platform (including Windows 10) support.
-```gfold``` is tested for the following systems, but may work on more...
+All external crates were vetted for support on all three major desktop platforms.
+```gfold``` is tested for the latest version of the following systems, but may work on more...
 
-- Linux amd64 (dynamically linked)
-- Linux amd64 (statically linked using MUSL)
-- macOS amd64
-- Windows 10 amd64
+- **Linux**: ```linux-gnu-amd64```
+- **macOS**: ```darwin-amd64```
+- **Windows 10**: ```windows-amd64```
 
 ## Changelog
 


### PR DESCRIPTION
Add slimmer build by combining the test and check steps. Remove MUSL
mentions from README, and make the tested binaries clearer.

This resolves issues: #37 and #21