### PR TITLE
Add binary publishing workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,7 +1,6 @@
 on: [push]
 name: merge
 jobs:
-
   pre-build:
     name: Pre-Build
     runs-on: ubuntu-latest
@@ -33,7 +32,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-
   build:
     name: Build
     runs-on: ${{ matrix.os }}
@@ -53,4 +51,3 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,29 @@ on:
     tags: ['*']
 name: release
 jobs:
-  dummy:
-    name: dummy
-    runs-on: ubuntu-latest
+  publish:
+    name: Publish for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: gfold
+            asset_name: gfold-${{ github.ref }}-linux-gnu-amd64
+          - os: windows-latest
+            artifact_name: gfold.exe
+            asset_name: gfold-${{ github.ref }}-windows-amd64
+          - os: macos-latest
+            artifact_name: gfold
+            asset_name: gfold-${{ github.ref }}-macos-amd64
     steps:
-      - name: hello-world
-        run: echo hello-world
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --release --locked
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/${{ matrix.artifact_name }}
+        asset_name: ${{ matrix.asset_name }}
+        tag: ${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<!-- The latest version contains all changes. -->
 
-The latest version contains all changes.
+### Added
+
+- Binary publishing workflow to the dummy file from [@nickgerace](https://github.com/nickgerace).
+
+### Changed
+
+- Existing merge workflow to use debug building instead of release building from [@nickgerace](https://github.com/nickgerace).
+- Makefile target containing the old default branch name from [@nickgerace](https://github.com/nickgerace).
+
+### Removed
+
+- Makefile target for statically-linked building from [@nickgerace](https://github.com/nickgerace).
 
 ## [0.5.1] - 2020-10-07
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,6 @@ install-local:
 build: fmt test
 	cd $(MAKEPATH); cargo build
 
-build-static: fmt test
-	@printf "Warning: gfold has deprecated this workflow.\n"
-	docker pull clux/muslrust
-	cd $(MAKEPATH); docker run -v $(MAKEPATH):/volume --rm -t clux/muslrust cargo build --release
-
 build-release: fmt test
 	cd $(MAKEPATH); cargo build --release
 
@@ -42,7 +37,7 @@ tree:
 
 tag:
 	cd $(MAKEPATH); git tag $(VERSION)
-	cd $(MAKEPATH); git push --tags origin master
+	cd $(MAKEPATH); git push --tags origin main
 
 fixme:
 	@cd $(MAKEPATH); grep -r \

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ gfold ..
 gfold $HOME
 gfold /this/is/an/absolute/path
 gfold ../../this/is/a/relative/path
-gfold ~/repositories/ -r
-gfold -r $HOME/repositories
+gfold ~/path/to/multiple/repositories/ -r
+gfold -r $HOME/path/to/multiple/repositories
 ```
 
 ## Compatibility
 
 All external crates were vetted for support on all three major desktop platforms.
-```gfold``` is tested for the latest version of the following systems, but may work on more...
+```gfold``` is tested for the latest versions of the following systems, but may work on more...
 
 - **Linux**: ```linux-gnu-amd64```
 - **macOS**: ```darwin-amd64```


### PR DESCRIPTION
Add binary publishing workflow to existing dummy release workflow.
Remove default branch reference from Makefile. Remove statically-linked
build target from Makefile. Switch to build debug instead of build
release for the merge workflow.

This resolves #43.