### PR TITLE
Add eyre for simple backtrace reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "eyre"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c5cb4dc433c59f09df4b4450f649cbfed61e8a3505abe32e4154066439157e"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +190,7 @@ dependencies = [
 name = "gfold"
 version = "0.5.2"
 dependencies = [
+ "eyre",
  "git2",
  "prettytable-rs",
  "structopt",
@@ -228,6 +239,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
 
 [[package]]
 name = "itoa"
@@ -316,6 +333,12 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "once_cell"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "openssl-probe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Nick Gerace <nickagerace@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+eyre = "0.6"
 structopt = "0.3"
 git2 = "0.13"
 prettytable-rs = "0.8"

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,14 @@ fixme:
 		FIXME $(MAKEPATH)
 
 release:
-	@printf "Change version at the following locations...\n"
+	@printf "[1] Change version at the following locations...\n"
 	@printf "    Makefile: $(shell grep $(VERSION) $(MAKEPATH)/Makefile)\n"
 	@printf "    README.md: $(shell grep $(VERSION) $(MAKEPATH)/README.md)\n"
 	@printf "    CHANGELOG.md: $(shell grep $(VERSION) $(MAKEPATH)/CHANGELOG.md)\n"
 	@printf "    Cargo.toml: $(shell grep $(VERSION) $(MAKEPATH)/Cargo.toml)\n"
-	@printf "Uncomment the unreleased string in CHANGELOG.md...\n"
+	@printf "[2] Uncomment the unreleased string in CHANGELOG.md...\n"
 	@printf "    <!--The latest version contains all changes.-->\n"
-	@printf "Then, run the following command...\n"
+	@printf "[3] Run the following command to check documentation...\n"
+	@printf "    cargo doc --open\n"
+	@printf "[4] Then, run the following command...\n"
 	@printf "    time make build-release\n"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@
 
 use std::env;
 use std::path::PathBuf;
-use std::process;
 
+use eyre::Result;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -30,7 +30,7 @@ struct Opt {
 
 /// This file, ```main.rs```, serves as the primary driver for the ```gfold``` library.
 /// It is intended to be used as a command-line interface.
-fn main() {
+fn main() -> Result<()> {
     let mut path = env::current_dir().expect("failed to get CWD");
 
     let opt = Opt::from_args();
@@ -39,8 +39,6 @@ fn main() {
     };
     path = path.canonicalize().expect("failed to canonicalize path");
 
-    if let Err(error) = gfold::run(&path, opt.recursive, opt.skip_sort) {
-        eprintln!("Encountered fatal error: {}", error);
-        process::exit(1);
-    };
+    gfold::run(&path, opt.recursive, opt.skip_sort)?;
+    Ok(())
 }


### PR DESCRIPTION
Add eyre for simple backtrace reporting. Since gfold relies on speed and
efficiency, and sports a relatively small codebase, eyre provides a
simple backtrace report when an error is encountered. Specifically, the
filename and line are the most important parts.

Closes: #52 