### PR TITLE
Fix PR template and extend license to 2021

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,29 @@
+---
+name: issue
+about: Describe the issue
+title: ''
+labels: ''
+assignees: nickgerace
+---
+
+## Describe the issue. Feel free to be descriptive.
+<!-- Insert answer below. -->
+
+## What are you attempting to do, and/or what did you expect? In other words, what is the motivation and context to this issue?
+<!-- Insert answer below. -->
+
+## Is this a bug report, feature request, or another type of issue? If this is a bug report, describe how to reproduce the issue.
+<!-- Insert answer below. -->
+
+## Are you using a pre-built binary? If not, please specify.
+<!-- Insert answer below. -->
+
+## What OS are you using, and at what version number?
+<!-- Insert answer below. -->
+
+## What CPU architecture are you using? If you do not know, it is most likely ```amd64``` or ```x86_64```. 
+<!-- Insert answer below. -->
+
+## Additional information (optional)
+<!-- Insert answer below. -->
+None.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,0 +1,4 @@
+<!-- Provide a general summary of your changes in the title above. -->
+
+## What issue does this pull request address?
+<!-- All pull requests must have an issue created first. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<!-- The latest version contains all changes. -->
 
-The latest version contains all changes.
+### Added
+
+- Code of Conduct link from [@nickgerace](https://github.com/nickgerace).
+- GitHub issue template from [@nickgerace](https://github.com/nickgerace).
+- GitHub pull request template from [@nickgerace](https://github.com/nickgerace).
 
 ## [0.6.0] - 2020-10-10
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Nick Gerace
+   Copyright 2020-2021 Nick Gerace
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -116,13 +116,17 @@ It is tested for the latest versions of the following systems, but may work on m
 Please check out [CHANGELOG.md](./CHANGELOG.md) for more information.
 It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
+## Code of Conduct
+
+This repository follows and enforces the Rust programming language's [Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).
+
 ## Additional Information
 
 - Author: [Nick Gerace](https://nickgerace.dev)
 - License: [Apache 2.0](./LICENSE)
 
-## Special Thanks
+## Special Thanks To...
 
-- [@yaahc](https://github.com/yaahc) (mentoring)
-- [@orhun](https://github.com/orhun) (maintaining [all three AUR packages](https://github.com/orhun/PKGBUILDs))
-- [@jrcichra](https://github.com/jrcichra) (adding multi-OS support to the original CI pipeline)
+- [@jrcichra](https://github.com/jrcichra) for adding multi-OS support to the original CI pipeline
+- [@orhun](https://github.com/orhun) for maintaining [all three AUR packages](https://github.com/orhun/PKGBUILDs)
+- [@yaahc](https://github.com/yaahc) for mentoring


### PR DESCRIPTION
Fix GitHub PR template through using the GitHub naming conventions.
Extend the Apache 2.0 license to 2021.

Guide used: [https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository)