### PR TITLE
Fix GitHub PR template and extend license to 2021

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,4 +1,0 @@
-<!-- Provide a general summary of your changes in the title above. -->
-
-## What issue does this pull request address?
-<!-- All pull requests must have an issue created first. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+<!-- Provide a general summary of your changes in the title above. -->
+
+## What issue does this pull request address?
+<!-- All pull requests must have an issue created first. -->
+Fixes: #
+
+## Additional Information (optional)
+<!-- Insert additional information below. -->
+None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub issue template from [@nickgerace](https://github.com/nickgerace).
 - GitHub pull request template from [@nickgerace](https://github.com/nickgerace).
 
+### Changed
+
+- LICENSE to be extended through 20201 from [@nickgerace](https://github.com/nickgerace).
+
 ## [0.6.0] - 2020-10-10
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Nick Gerace
+   Copyright 2020-2021 Nick Gerace
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix GitHub PR template through using the GitHub naming conventions.
Extend the Apache 2.0 license to 2021.

Guide used: [https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository)