### PR TITLE
Add Homebrew installation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,186 +1,195 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+All changes are from [@nickgerace](https://github.com/nickgerace) unless otherwise specified.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<!--The latest version contains all changes.-->
 
-The latest version contains all changes.
+### Added
+
+- Homebrew tap
+
+### Changed
+
+- README mentions of specific version tags
+- README plaintext blocks to single quotes when mixed with formatted text
+- README to sort installation method by package managers first
 
 ## [0.6.2] - 2020-11-03
 
 ### Added
 
-- No color flag and functionality from [@nickgerace](https://github.com/nickgerace).
+- No color flag and functionality
 
 ### Removed
 
-- Pull request template from [@nickgerace](https://github.com/nickgerace).
+- Pull request template
 
 ## [0.6.1] - 2020-10-12
 
 ### Added
 
-- Code of Conduct link from [@nickgerace](https://github.com/nickgerace).
-- GitHub issue template from [@nickgerace](https://github.com/nickgerace).
-- GitHub pull request template from [@nickgerace](https://github.com/nickgerace).
+- Code of Conduct link
+- GitHub issue template
+- GitHub pull request template
 
 ### Changed
 
-- LICENSE to be extended through 2021 from [@nickgerace](https://github.com/nickgerace).
-- Match blocks in ```lib.rs``` to be consolidated from [@nickgerace](https://github.com/nickgerace).
-- Nearly all contents of ```lib.rs``` to return errors back to the calling function in ```main.rs``` from [@nickgerace](https://github.com/nickgerace).
+- LICENSE to be extended through 2021
+- Match blocks in ```lib.rs``` to be consolidated
+- Nearly all contents of ```lib.rs``` to return errors back to the calling function in ```main.rs```
 
 ### Removed
 
-- Duplicate code related to the match block consolidation from [@nickgerace](https://github.com/nickgerace).
+- Duplicate code related to the match block consolidation
 
 ## [0.6.0] - 2020-10-10
 
 ### Added
 
-- Doc comments and ```cargo doc``` to ```release``` target from [@nickgerace](https://github.com/nickgerace).
-- ```eyre``` for simple backtrace reporting from [@nickgerace](https://github.com/nickgerace).
-- ```gfold-bin``` to AUR portion of README from [@nickgerace](https://github.com/nickgerace).
-- ```lib.rs``` as part of major refactor from [@nickgerace](https://github.com/nickgerace).
+- Doc comments and ```cargo doc``` to ```release``` target
+- ```eyre``` for simple backtrace reporting
+- ```gfold-bin``` to AUR portion of README
+- ```lib.rs``` as part of major refactor
 
 ### Changed
 
-- Pre-build Makefile targets to be consolidated from [@nickgerace](https://github.com/nickgerace).
-- Refactor source code to be driven by a library, helmed by ```lib.rs``` from [@nickgerace](https://github.com/nickgerace).
+- Pre-build Makefile targets to be consolidated
+- Refactor source code to be driven by a library, helmed by ```lib.rs```
 
 ### Removed
 
-- ```util.rs``` and ```gfold.rs``` as part of major refactor from [@nickgerace](https://github.com/nickgerace).
+- ```util.rs``` and ```gfold.rs``` as part of major refactor
 
 ## [0.5.2] - 2020-10-08
 
 ### Added
 
-- GitHub release downloads to README from [@nickgerace](https://github.com/nickgerace).
-- Binary publishing workflow to the dummy file from [@nickgerace](https://github.com/nickgerace).
+- GitHub release downloads to README
+- Binary publishing workflow to the dummy file
 
 ### Changed
 
-- Existing merge workflow to use debug building instead of release building from [@nickgerace](https://github.com/nickgerace).
-- Makefile target containing the old default branch name from [@nickgerace](https://github.com/nickgerace).
+- Existing merge workflow to use debug building instead of release building
+- Makefile target containing the old default branch name
 
 ### Removed
 
-- Makefile target for statically-linked building from [@nickgerace](https://github.com/nickgerace).
+- Makefile target for statically-linked building
 
 ## [0.5.1] - 2020-10-07
 
 ### Added
 
-- Release dummy GitHub Action from [@nickgerace](https://github.com/nickgerace).
-- Version README badge from [@nickgerace](https://github.com/nickgerace).
+- Release dummy GitHub Action
+- Version README badge
 
 ### Changed
 
-- A reduction to CI build time and complexity by combining the test and check steps, from [@nickgerace](https://github.com/nickgerace).
-- GitHub workflow "merge" file name to "merge.yml" from [@nickgerace](https://github.com/nickgerace).
-- GitHub workflow name to "merge" from [@nickgerace](https://github.com/nickgerace).
-- OS compatibility claims in README through a simplified list from [@nickgerace](https://github.com/nickgerace).
-- README badges to use shields.io from [@nickgerace](https://github.com/nickgerace).
+- A reduction to CI build time and complexity by combining the test and check steps,
+- GitHub workflow "merge" file name to "merge.yml"
+- GitHub workflow name to "merge"
+- OS compatibility claims in README through a simplified list
+- README badges to use shields.io
 
 ### Removed 
 
-- MUSL mentions in docs from [@nickgerace](https://github.com/nickgerace).
+- MUSL mentions in docs
 
 ## [0.5.0] - 2020-09-02
 
 ### Added
 
-- Recursive search feature and flag from [@nickgerace](https://github.com/nickgerace).
-- Skip sort feature and flag from [@nickgerace](https://github.com/nickgerace).
-- Unit tests for recursive search and skip sort from [@nickgerace](https://github.com/nickgerace).
-- AUR PKGBUILD GitHub repository to README from [@nickgerace](https://github.com/nickgerace).
-- Results and TableWrapper structs, and relevant functions, from [@nickgerace](https://github.com/nickgerace).
-- Three methods for Results struct (printing/sorting/populating results) from [@nickgerace](https://github.com/nickgerace).
-- Make targets for ```run-recursive``` and ```install-local``` from [@nickgerace](https://github.com/nickgerace).
+- Recursive search feature and flag
+- Skip sort feature and flag
+- Unit tests for recursive search and skip sort
+- AUR PKGBUILD GitHub repository to README
+- Results and TableWrapper structs, and relevant functions,
+- Three methods for Results struct (printing/sorting/populating results)
+- Make targets for ```run-recursive``` and ```install-local```
 
 ### Changed
 
-- Switch from ```walk_dir``` function to object-driven harness for execution from [@nickgerace](https://github.com/nickgerace).
-- Move ```walk_dir``` function logic to ```Results``` method from [@nickgerace](https://github.com/nickgerace).
-- Function ```is_git_repo``` to its own file from [@nickgerace](https://github.com/nickgerace).
-- Any unnecessary match block to use "expect" instead from [@nickgerace](https://github.com/nickgerace).
-- Cargo install to use a specific tag from [@nickgerace](https://github.com/nickgerace).
-- Version upgrade workflow to Makefile from [@nickgerace](https://github.com/nickgerace).
+- Switch from ```walk_dir``` function to object-driven harness for execution
+- Move ```walk_dir``` function logic to ```Results``` method
+- Function ```is_git_repo``` to its own file
+- Any unnecessary match block to use "expect" instead
+- Cargo install to use a specific tag
+- Version upgrade workflow to Makefile
 
 ### Removed
 
-- Leftover "FIXME" comments for recursive search ideas from [@nickgerace](https://github.com/nickgerace).
+- Leftover "FIXME" comments for recursive search ideas
 
 ## [0.4.0] - 2020-08-31
 
 ### Added
 
-- Changelog from [@nickgerace](https://github.com/nickgerace).
-- Tags automation from [@nickgerace](https://github.com/nickgerace).
+- Changelog
+- Tags automation
 
 ### Changed
 
-- Example output to use mythical repositories from [@nickgerace](https://github.com/nickgerace).
-- Path flag to positional argument from [@nickgerace](https://github.com/nickgerace).
-- Switched to structopt library for CLI parsing from [@nickgerace](https://github.com/nickgerace).
+- Example output to use mythical repositories
+- Path flag to positional argument
+- Switched to structopt library for CLI parsing
 
 ### Removed
 
-- Tag v0.3.0 (duplicate of 0.3.0 with the "v" character) from [@nickgerace](https://github.com/nickgerace).
-- All GitHub releases before 0.3.1 from [@nickgerace](https://github.com/nickgerace).
-- Releases information from README from [@nickgerace](https://github.com/nickgerace).
+- Tag v0.3.0 (duplicate of 0.3.0 with the "v" character)
+- All GitHub releases before 0.3.1
+- Releases information from README
 
 ## [0.3.1] - 2020-08-30
 
 ### Added
 
-- Add AUR installation documentation from [@nickgerace](https://github.com/nickgerace).
-- Add AUR packages from [@orhun](https://github.com/orhun).
+- Add AUR installation documentation
+- Add AUR packages from [@orhun](https://github.com/orhun)
 
 ### Changed
 
-- Switch to Apache 2.0 license from MIT license from [@nickgerace](https://github.com/nickgerace).
-- Reorganize build tags, and add test build target from [@nickgerace](https://github.com/nickgerace).
+- Switch to Apache 2.0 license from MIT license
+- Reorganize build tags, and add test build target
 
 ## [0.3.0] - 2020-08-24
 
 ### Changed
 
-- Handling for bare repositories to print their status to STDOUT from [@nickgerace](https://github.com/nickgerace) with the mentorship of [@yaahc](https://github.com/yaahc).
+- Handling for bare repositories to print their status to STDOUT with the mentorship of [@yaahc](https://github.com/yaahc)
 
 ## [0.2.2] - 2020-08-24
 
 ### Changed
 
-- "Continue" to the next repository object if the current object is bare from [@nickgerace](https://github.com/nickgerace).
-- Release availability in README from [@nickgerace](https://github.com/nickgerace).
+- "Continue" to the next repository object if the current object is bare
+- Release availability in README
 
 ## [0.2.1] - 2020-06-08
 
 ### Added
 
-- Experimental statically-linked, MUSL support from [@nickgerace](https://github.com/nickgerace).
+- Experimental statically-linked, MUSL support
 
 ## [0.2.0] - 2020-05-10
 
 ### Changed
 
-- Switched to prettytable-rs from [@nickgerace](https://github.com/nickgerace).
-- Unit tests to work with prettytable-rs from [@nickgerace](https://github.com/nickgerace).
+- Switched to prettytable-rs
+- Unit tests to work with prettytable-rs
 
 ## [0.1.1] - 2020-04-10
 
 ### Added
 
-- Example output, contributors, and usage in README from [@nickgerace](https://github.com/nickgerace).
-- Building for Windows, macOS, and Linux amd64 in CI pipeline from [@jrcichra](https://github.com/jrcichra).
+- Example output, contributors, and usage in README
+- Building for Windows, macOS, and Linux amd64 in CI pipeline from [@jrcichra](https://github.com/jrcichra)
 
 ## [0.1.0] - 2020-04-08
 
 ### Added
 
-- Base contents from [@nickgerace](https://github.com/nickgerace).
+- Base contents

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ fixme:
 release:
 	@printf "[1] Change version at the following locations...\n"
 	@printf "    Makefile:\n        $(shell grep $(VERSION) $(MAKEPATH)/Makefile)\n"
-	@printf "    README.md:\n        $(shell grep $(VERSION) $(MAKEPATH)/README.md)\n"
 	@printf "    CHANGELOG.md:\n        $(shell grep $(VERSION) $(MAKEPATH)/CHANGELOG.md)\n"
 	@printf "    Cargo.toml:\n        $(shell grep $(VERSION) $(MAKEPATH)/Cargo.toml)\n"
 	@printf "[2] Uncomment the unreleased string in CHANGELOG.md...\n"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest SemVer GitHub Tag](https://img.shields.io/github/v/tag/nickgerace/gfold?label=version&style=flat-square)](https://github.com/nickgerace/gfold/releases/latest)
 [![Build Status](https://img.shields.io/github/workflow/status/nickgerace/gfold/merge/main?style=flat-square)](https://github.com/nickgerace/gfold/actions?query=workflow%3Amerge+branch%3Amain)
 
-```gfold``` is a CLI application that helps you keep track of multiple Git repositories.
+`gfold` is a CLI application that helps you keep track of multiple Git repositories.
 
 ```bash
 user at hostname in ~/git
@@ -23,26 +23,68 @@ This app displays relevant information for multiple Git repositories in one, or 
 While this tool might seem limited in scope and purpose, that is by design.
 
 It prints each repository in alphabetical order, and pads each result based on the longest directory, branch, and status string.
-By default, ```gfold``` looks at every Git repository in the current working directory.
+By default, `gfold` looks at every Git repository in the current working directory.
 However, if you would like to target another directory, you can pass that path (relative or absolute) as the first argument.
 
 ## Installation
 
-There are multiple ways to install ```gfold```, but here are the currently recommended methods...
+There are multiple ways to install `gfold`, but here are some recommended methods...
 
-### 1. Download a GitHub Binary
+Installation Methods | `linux-gnu-amd64` | `macos-amd64` | `windows-amd64`
+--- | --- | --- | --
+Homebrew | x | x | -
+Arch User Repository (AUR) | x | - | -
+Cargo Install | x | x | x
+GitHub Release Binary | x | x | x
 
-Most likely, the easiest method of obtaining ```gfold``` is via the [latest GitHub release](https://github.com/nickgerace/gfold/releases/latest).
+### Homebrew
 
-Once you have it downloaded, you can add it to your ```PATH```.
+You can use [Homebrew](https://brew.sh) to install the [tap](https://github.com/nickgerace/homebrew-gfold) for `gfold`.
+
+```bash
+brew install nickgerace/gfold/gfold
+```
+
+Alternatively, you can do...
+
+```bash
+brew tap nickgerace/gfold
+brew install gfold
+```
+
+Running `brew help` or `man brew` can help you use `brew` locally.
+You can check out [Homebrew's documentation](https://docs.brew.sh) as well.
+
+### Arch User Repository (AUR)
+
+This application is available for all Linux distributions that support installing packages from the AUR.
+
+- [gfold](https://aur.archlinux.org/packages/gfold/) (builds from source)
+- [gfold-bin](https://aur.archlinux.org/packages/gfold-bin/) (uses the GitHub release binary)
+- [gfold-git](https://aur.archlinux.org/packages/gfold-git/) (VCS/development package)
+
+Many people choose to use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), such as [yay](https://github.com/Jguer/yay) (example: `yay -S gfold`), in order to install their AUR packages.
+
+### Cargo Install
+
+You can build from source with `cargo` by executing the following...
+
+```bash
+cargo install --git https://github.com/nickgerace/gfold --tag <version>
+```
+
+### GitHub Release Binary
+
+You can obtain `gfold` via the [latest GitHub release](https://github.com/nickgerace/gfold/releases/latest).
+Once you have it downloaded, you can add it to your `PATH`.
 Here is an example on how to do that on macOS and Linux...
 
 ```bash
 chmod +x gfold
-sudo mv gfold /usr/local/bin/
+mv gfold /usr/local/bin/
 ```
 
-You may have to reload your shell in order to see ```gfold``` in your ```PATH```.
+You may have to reload your shell in order to see `gfold` in your `PATH`.
 
 #### Advanced Management
 
@@ -50,7 +92,7 @@ You can use symbolic links to swap between versions, and manage multiple at a ti
 Here is a full install workflow example...
 
 ```bash
-VERSION=0.6.2
+VERSION=<version>
 PLATFORM=linux-gnu-amd64
 
 wget https://github.com/nickgerace/gfold/releases/download/$VERSION/gfold-$PLATFORM
@@ -62,29 +104,11 @@ mv gfold-$VERSION /usr/local/gfold/
 ln -s /usr/local/gfold/gfold-$VERSION /usr/local/bin/gfold
 ```
 
-Now, you can add/remove versions of the binary from ```/usr/local/gfold/```, and change the symbolic link as needed.
-
-### 2. Arch User Repository (AUR)
-
-This application is available for all Linux distributions that support installing packages from the AUR.
-
-- [gfold](https://aur.archlinux.org/packages/gfold/) (builds from source)
-- [gfold-bin](https://aur.archlinux.org/packages/gfold-bin/) (uses the GitHub release binary)
-- [gfold-git](https://aur.archlinux.org/packages/gfold-git/) (VCS/development package)
-
-Many people choose to use an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers), such as [yay](https://github.com/Jguer/yay) (example: ```yay -S gfold```), in order to install their AUR packages.
-
-### 3. Cargo Install
-
-You can build from source with ```cargo``` by executing the following...
-
-```bash
-cargo install --git https://github.com/nickgerace/gfold --tag 0.6.2
-```
+Now, you can add/remove versions of the binary from `/usr/local/gfold/`, and change the symbolic link as needed.
 
 ## Usage
 
-For all the ways on how to use this application, pass in the ```-h```, or ```--help```, flag.
+For all the ways on how to use this application, pass in the `-h`, or `--help`, flag.
 
 ```bash
 gfold --help
@@ -104,12 +128,12 @@ gfold -r $HOME/path/to/multiple/repositories
 
 ## Compatibility
 
-```gfold```, and its external crates, support all three major desktop platforms.
+`gfold`, and its external crates, support all three major desktop platforms.
 It is tested for the latest versions of the following systems, but may work on more...
 
-- **Linux**: ```linux-gnu-amd64```
-- **macOS**: ```macos-amd64```
-- **Windows 10**: ```windows-amd64```
+- **Linux**: `linux-gnu-amd64`
+- **macOS**: `macos-amd64`
+- **Windows 10**: `windows-amd64`
 
 ## Changelog
 


### PR DESCRIPTION
Add Homebrew installation method. Add installation methods table to
README. Sort installation methods by preferring package managers first.
Remove specific tag mentions from README.

Closes: #36 
Closes: #64 