### PR TITLE
Add post release process and contributing info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,10 @@ pre-build:
 doc:
 	cd $(MAKEPATH); cargo doc --open
 
-tag:
+tag-release:
 	cd $(MAKEPATH); git tag $(VERSION)
 	cd $(MAKEPATH); git push --tags origin main
+	cd $(MAKEPATH); cargo publish
 
 fixme:
 	@cd $(MAKEPATH); grep -r \
@@ -60,4 +61,11 @@ release:
 	@printf "    time make build-release\n"
 	@printf "[4] Before merging, ensure that publishing works.\n"
 	@printf "    cargo publish --dry-run\n"
+
+post-release:
+	@printf "[1] Run the following command...\n"
+	@printf "    time make tag-release\n"
+	@printf "[2] Edit the GitHub release page for the new release.\n"
+	@printf "[3] Check crates.io: https://crates.io/crates/gfold\n"
+	@printf "[4] Update Homebrew tap version: https://github.com/nickgerace/homebrew-gfold\n"
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ It is tested for the latest versions of the following systems, but may work on m
 - **macOS**: `macos-amd64`
 - **Windows 10**: `windows-amd64`
 
+## Issues, Pull Requests, and Contributing
+
+Please follow the issue template when filing an issue.
+If making a pull request, the requirements for merging are...
+
+1. An issue must be linked, whether it is a new one or an existing one.
+2. The pull request branch needs to be rebased with `nickgerace/gfold` on `main`.
+3. Pull request commits need to be squashed (there may be exceptions to this on a case-by-case basis).
+
 ## Changelog
 
 Please check out [CHANGELOG.md](./CHANGELOG.md) for more information.


### PR DESCRIPTION
Add post release process, which includes GitHub releases, crates.io,
and Homebrew. Add contributing information for PRs and issues.

Closes: #73 