### PR TITLE
Consolidate boolean test permutations to one test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@ All changes are from [@nickgerace](https://github.com/nickgerace) unless otherwi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<!--The latest version contains all changes.-->
 
-The latest version contains all changes.
+### Added
+
+- In-depth description of the `run` function
+
+### Changed
+
+- Consolidated boolean test permutations into one test
+
+### Removed
+
+- All non-public comments in `*.rs` files
 
 ## [0.7.0] - 2020-11-11
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ fixme:
 		--exclude-dir={target,.git} \
 		--exclude=Cargo.lock \
 		--exclude=CHANGELOG.md \
+		--exclude=Makefile \
 		--color=always \
 		FIXME $(MAKEPATH)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,6 @@ struct Opt {
     skip_sort: bool,
 }
 
-/// This file, ```main.rs```, serves as the primary driver for the ```gfold``` library.
-/// It is intended to be used as a command-line interface.
 fn main() -> Result<()> {
     let mut path = env::current_dir()?;
 


### PR DESCRIPTION
Consolidate boolean test permutations to one test. Remove non-public
comments from code. Add in-depth description for run function.

Closes: #77 