### PR TITLE
Update issue template questions to be one size

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -6,18 +6,14 @@ labels: ''
 assignees: nickgerace
 ---
 
-## Description
+### Describe the issue.
 <!--answer-here-->
 
-## Environment Details
-
-Please feel free to add any additional details beyond the questions below.
-
-#### Is this a bug report, feature request, or another type of issue?
+### Is this a bug report, feature request, or another type of issue?
 <!--answer-here-->
 
-#### Are you using Windows, macOS, Linux, or another OS?
+### Are you using Windows, macOS, Linux, or another OS?
 <!--answer-here-->
 
-#### Are you using a pre-built binary? If not, how did you obtain `gfold`?
+### Are you using a pre-built binary? If not, how did you obtain `gfold`?
 <!--answer-here-->


### PR DESCRIPTION
Update issue template questions to be one size. This is a follow-up to
the previous issue template change: 84962f609c1ea0e3255a778683e38f83b58f833c

Related issue: #84