### PR TITLE
Add disable unpushed commit check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ All changes are from [@nickgerace](https://github.com/nickgerace) unless otherwi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+<!-- The latest version contains all changes. -->
 
-The latest version contains all changes.
+### Added
+
+- Disable unpushed commit check flag and functionality
+- Logging for origin and local reference names for unpushed commit check
 
 ## [0.8.2] - 2020-12-14
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -16,6 +16,7 @@ use log::debug;
 
 #[derive(Debug)]
 pub struct Config {
+    pub disable_unpushed_check: bool,
     pub no_color: bool,
     pub recursive: bool,
     pub skip_sort: bool,
@@ -78,9 +79,12 @@ impl Results {
             if !&config.skip_sort {
                 repos.sort();
             }
-            if let Some(table_wrapper) =
-                util::create_table_from_paths(repos, &dir, &config.no_color)
-            {
+            if let Some(table_wrapper) = util::create_table_from_paths(
+                repos,
+                &dir,
+                &config.disable_unpushed_check,
+                &config.no_color,
+            ) {
                 self.0.push(table_wrapper);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,15 @@ use eyre::Result;
 /// - `skip_sort`: skips sorting the repositories for output
 ///
 /// When executed, results will be printed to STDOUT.
-pub fn run(path: &Path, no_color: bool, recursive: bool, skip_sort: bool) -> Result<()> {
+pub fn run(
+    path: &Path,
+    disable_unpushed_check: bool,
+    no_color: bool,
+    recursive: bool,
+    skip_sort: bool,
+) -> Result<()> {
     let config = driver::Config {
+        disable_unpushed_check,
         no_color,
         recursive,
         skip_sort,
@@ -44,14 +51,14 @@ mod tests {
     #[test]
     fn current_directory() {
         let current_dir = env::current_dir().expect("failed to get CWD");
-        assert_ne!(run(&current_dir, false, false, false).is_err(), true);
+        assert_ne!(run(&current_dir, false, false, false, false).is_err(), true);
     }
 
     #[test]
     fn parent_directory() {
         let mut current_dir = env::current_dir().expect("failed to get CWD");
         current_dir.pop();
-        assert_ne!(run(&current_dir, false, false, false).is_err(), true);
+        assert_ne!(run(&current_dir, false, false, false, false).is_err(), true);
     }
 
     #[test]
@@ -59,14 +66,14 @@ mod tests {
         let mut current_dir = env::current_dir().expect("failed to get CWD");
         current_dir.pop();
 
-        assert_ne!(run(&current_dir, true, false, false).is_err(), true);
-        assert_ne!(run(&current_dir, true, false, true).is_err(), true);
-        assert_ne!(run(&current_dir, true, true, false).is_err(), true);
+        assert_ne!(run(&current_dir, false, true, false, false).is_err(), true);
+        assert_ne!(run(&current_dir, false, true, false, true).is_err(), true);
+        assert_ne!(run(&current_dir, false, true, true, false).is_err(), true);
 
-        assert_ne!(run(&current_dir, false, true, false).is_err(), true);
-        assert_ne!(run(&current_dir, false, true, true).is_err(), true);
-        assert_ne!(run(&current_dir, false, false, true).is_err(), true);
+        assert_ne!(run(&current_dir, false, false, true, false).is_err(), true);
+        assert_ne!(run(&current_dir, false, false, true, true).is_err(), true);
+        assert_ne!(run(&current_dir, false, false, false, true).is_err(), true);
 
-        assert_ne!(run(&current_dir, true, true, true).is_err(), true);
+        assert_ne!(run(&current_dir, false, true, true, true).is_err(), true);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ working directory."
 struct Opt {
     #[structopt(short, long, help = "Set to debug mode")]
     debug: bool,
+    #[structopt(short, long, help = "Toggle to disable checking for unpushed commits")]
+    disable_unpushed_check: bool,
     #[structopt(long = "nc", help = "Disable color output")]
     no_color: bool,
     #[structopt(parse(from_os_str), help = "Target a different directory")]
@@ -46,6 +48,12 @@ fn main() -> Result<()> {
     };
     path = path.canonicalize()?;
 
-    gfold::run(&path, opt.no_color, opt.recursive, opt.skip_sort)?;
+    gfold::run(
+        &path,
+        opt.disable_unpushed_check,
+        opt.no_color,
+        opt.recursive,
+        opt.skip_sort,
+    )?;
     Ok(())
 }


### PR DESCRIPTION
Add disable unpushed commit check to give users a choice. The unpushed
function currently does not account for every case, so having the flag
is a temporary solution that may also provide useful in its own right.