### PR TITLE
Switch to tracing from log and add debug flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Codebase to a domain-driven architecture for easier refactoring
+- Codebase to a domain-driven architecture
 
 ## [2.0.2] - 2021-12-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,17 +125,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,13 +142,13 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs",
- "env_logger",
- "log",
  "rayon",
  "serde",
  "serde_json",
  "termcolor",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -198,12 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +184,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -232,12 +210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
-name = "log"
-version = "0.4.14"
+name = "matchers"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "cfg-if",
+ "regex-automata",
 ]
 
 [[package]]
@@ -266,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +257,12 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "proc-macro-error"
@@ -361,6 +351,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,9 +412,18 @@ version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -453,6 +476,86 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "itoa 0.4.8",
+ "libc",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
+dependencies = [
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "thread_local",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,20 @@ version = "2.0.2"
 [dependencies]
 anyhow = "1"
 dirs = "4"
-log = "0"
-rayon = { version = "1", default-features = false }
+rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 termcolor = "1"
 thiserror = "1"
+tracing = "0"
 
 # Source: https://github.com/clap-rs/clap/tree/v3.0.0-rc.7#optional-features
+# Removed features: ["color"]
 clap = { version = "3.0.0-rc.7", features = ["derive", "std", "suggestions"], default_features = false }
 
-# Source: https://github.com/env-logger-rs/env_logger/blob/v0.9.0/Cargo.toml#L47
-env_logger = { version = "0", features = ["atty", "humantime"], default_features = false }
+# Source: https://docs.rs/tracing-subscriber/0.3.3/tracing_subscriber/index.html#feature-flags
+# Removed features: ["ansi"]
+tracing-subscriber = { version = "0", features = ["std", "alloc", "env-filter", "fmt", "registry", "json", "local-time"], default_features = false }
 
 [profile.release]
 codegen-units = 1

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
-use crate::config::{Config, Mode};
-use crate::run;
+use crate::config::{Config, DisplayMode};
+use crate::{logging, run};
 use anyhow::Result;
 use clap::Parser;
 use std::env;
@@ -22,6 +22,8 @@ operating systems:
     Windows        {FOLDERID_Profile}\\.config\\gfold\\gfold.json",
 )]
 struct Opt {
+    #[clap(long, help = "Enable debug logging (sets \"RUST_LOG\" to \"debug\")")]
+    debug: bool,
     #[clap(long, help = "(TODO) Display results with the new output mode")]
     new: bool,
     #[clap(help = "Path to target directory (defaults to current working directory)")]
@@ -31,14 +33,17 @@ struct Opt {
 }
 
 pub fn parse() -> Result<()> {
+    // First and foremost, get logging up and running.
+    let opt = Opt::parse();
+    logging::init(opt.debug);
+
     let mut config = Config::try_config()?;
 
-    let opt = Opt::parse();
     if let Some(s) = opt.path {
         config.default_path = Some(env::current_dir()?.join(s).canonicalize()?);
     }
     if opt.new {
-        config.mode = Some(Mode::Modern);
+        config.display_mode = Some(DisplayMode::Modern);
     }
 
     // Set remaining "None" options to their defaults, if needed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,20 @@
 use crate::error::Error;
 use anyhow::Result;
-use log::warn;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
+use tracing::warn;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Config {
     pub default_path: Option<PathBuf>,
-    pub mode: Option<Mode>,
+    pub display_mode: Option<DisplayMode>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum Mode {
+pub enum DisplayMode {
     Classic,
     Modern,
 }
@@ -32,7 +32,7 @@ impl Config {
                 warn!("{}", e);
                 Ok(Config {
                     default_path: None,
-                    mode: None,
+                    display_mode: None,
                 })
             }
         }
@@ -42,8 +42,8 @@ impl Config {
         if self.default_path.is_none() {
             self.default_path = Some(env::current_dir()?.canonicalize()?);
         }
-        if self.mode.is_none() {
-            self.mode = Some(Mode::Classic)
+        if self.display_mode.is_none() {
+            self.display_mode = Some(DisplayMode::Classic)
         }
         Ok(())
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,8 +1,10 @@
 use std::env;
 
-pub fn init() {
-    if env::var("RUST_LOG").is_err() {
+pub fn init(debug: bool) {
+    if debug {
+        env::set_var("RUST_LOG", "debug")
+    } else if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", "off");
     }
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ mod status;
 mod target_gen;
 
 fn main() -> Result<()> {
-    logging::init();
     cli::parse()
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, Mode};
+use crate::config::{Config, DisplayMode};
 use crate::display;
 use crate::error::Error;
 use crate::report::Reports;
@@ -10,9 +10,9 @@ pub fn run(config: &Config) -> Result<()> {
         Some(s) => s,
         None => return Err(Error::EmptyConfigOption(config.to_owned()).into()),
     })?)?;
-    match config.mode {
-        Some(Mode::Modern) => display::modern(&reports),
-        Some(Mode::Classic) => display::classic(&reports),
+    match config.display_mode {
+        Some(DisplayMode::Modern) => display::modern(&reports),
+        Some(DisplayMode::Classic) => display::classic(&reports),
         None => Err(Error::EmptyConfigOption(config.to_owned()).into()),
     }
 }

--- a/src/target_gen.rs
+++ b/src/target_gen.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use log::{error, warn};
 use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
+use tracing::{error, warn};
 
 pub struct Targets(pub Vec<PathBuf>);
 


### PR DESCRIPTION
- Switch to tracing and tracing-subscriber from log and env_logger
- Add debug flag to set RUST_LOG
- Rename Mode enum to DisplayMode for clarity
- Sift through all dependencies for default features and disable as
  needed (specifically, all color-based ones)