### PR TITLE
Finish standard display mode and split config types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 
 [[package]]
 name = "argh"

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,11 @@ ci:
 	cd $(MAKEPATH); cargo test -- --nocapture
 .PHONY: ci
 
-build:
+release:
 	cd $(MAKEPATH); cargo build --release
+.PHONY: release
+
+build: release
 .PHONY: build
 
 scan:
@@ -31,7 +34,7 @@ scan:
 	cd $(MAKEPATH); cargo audit
 .PHONY: scan
 
-bench-loosely: build
+bench-loosely:
 	@echo "============================================================="
 	@time $(INSTALLED) ~/
 	@echo "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,16 +23,13 @@ struct Args {
         description = "path to target directory (defaults to current working directory)"
     )]
     path: Option<String>,
+    #[argh(switch, description = "display results with classic formatting")]
+    classic: bool,
     #[argh(
         switch,
         description = "enable debug logging (sets \"RUST_LOG\" to \"debug\")"
     )]
     debug: bool,
-    #[argh(
-        switch,
-        description = "(TODO) display results with the new output mode"
-    )]
-    new: bool,
     #[argh(switch, description = "display merged config options")]
     print: bool,
     #[argh(switch, short = 'V', description = "display version information")]
@@ -58,8 +55,8 @@ fn merge_config_and_run(args: &Args) -> Result<()> {
     if let Some(s) = &args.path {
         config.default_path = Some(env::current_dir()?.join(s).canonicalize()?);
     }
-    if args.new {
-        config.display_mode = Some(DisplayMode::Modern);
+    if args.classic {
+        config.display_mode = Some(DisplayMode::Classic);
     }
 
     // Set remaining "None" options to their defaults, if needed.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,14 +53,11 @@ fn merge_config_and_run(args: &Args) -> Result<()> {
     let mut config = Config::try_config()?;
 
     if let Some(s) = &args.path {
-        config.default_path = Some(env::current_dir()?.join(s).canonicalize()?);
+        config.path = env::current_dir()?.join(s).canonicalize()?;
     }
     if args.classic {
-        config.display_mode = Some(DisplayMode::Classic);
+        config.display_mode = DisplayMode::Classic;
     }
-
-    // Set remaining "None" options to their defaults, if needed.
-    config.set_defaults_if_empty()?;
 
     match args.print {
         true => config.print(),

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,7 +2,11 @@ use crate::status::Status;
 use std::io::{self, Write};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-pub fn write_status(status: &Status, status_width: usize) -> io::Result<()> {
+pub fn write_status(
+    status: &Status,
+    status_as_string: &str,
+    status_width: usize,
+) -> io::Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
     stdout.set_color(ColorSpec::new().set_fg(Some(match status {
         Status::Bare => Color::Red,
@@ -12,12 +16,7 @@ pub fn write_status(status: &Status, status_width: usize) -> io::Result<()> {
     write!(
         &mut stdout,
         "{:<status_width$}",
-        match status {
-            Status::Bare => "bare",
-            Status::Clean => "clean",
-            Status::Unclean => "unclean",
-            Status::Unpushed => "unpushed",
-        },
+        status_as_string,
         status_width = status_width,
     )?;
     stdout.reset()

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,13 +7,19 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct Config {
-    pub default_path: Option<PathBuf>,
+#[derive(Deserialize, Default)]
+pub struct EntryConfig {
+    pub path: Option<PathBuf>,
     pub display_mode: Option<DisplayMode>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize)]
+pub struct Config {
+    pub path: PathBuf,
+    pub display_mode: DisplayMode,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 pub enum DisplayMode {
     Standard,
     Classic,
@@ -22,42 +28,34 @@ pub enum DisplayMode {
 impl Config {
     pub fn try_config() -> Result<Config> {
         let home = dirs::home_dir().ok_or(Error::HomeDirNotFound)?;
-        match File::open(home.join(".config").join("gfold").join("gfold.json")) {
+        let entry_config = match File::open(home.join(".config").join("gfold").join("gfold.json")) {
             Ok(o) => {
                 let reader = BufReader::new(o);
-                let config: Config = serde_json::from_reader(reader)?;
-                Ok(config)
+                serde_json::from_reader(reader)?
             }
             Err(e) => {
                 warn!("{}", e);
-                Ok(Config {
-                    default_path: None,
-                    display_mode: None,
-                })
+                EntryConfig::default()
             }
-        }
-    }
-
-    pub fn set_defaults_if_empty(&mut self) -> Result<()> {
-        if self.default_path.is_none() {
-            self.default_path = Some(env::current_dir()?.canonicalize()?);
-        }
-        if self.display_mode.is_none() {
-            self.display_mode = Some(DisplayMode::Standard)
-        }
-        Ok(())
+        };
+        entry_config_to_config(&entry_config)
     }
 
     pub fn print(self) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&self)?);
         Ok(())
     }
+}
 
-    pub fn determine_display_mode(&self) -> Result<DisplayMode> {
-        match self.display_mode {
-            Some(DisplayMode::Standard) => Ok(DisplayMode::Standard),
-            Some(DisplayMode::Classic) => Ok(DisplayMode::Classic),
-            None => Err(Error::EmptyConfigOption(self.to_owned()).into()),
-        }
-    }
+pub fn entry_config_to_config(entry_config: &EntryConfig) -> Result<Config> {
+    Ok(Config {
+        path: match &entry_config.path {
+            Some(s) => s.clone(),
+            None => env::current_dir()?.canonicalize()?,
+        },
+        display_mode: match &entry_config.display_mode {
+            Some(s) => s.clone(),
+            None => DisplayMode::Standard,
+        },
+    })
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,8 @@ pub struct Config {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DisplayMode {
+    Standard,
     Classic,
-    Modern,
 }
 
 impl Config {
@@ -43,7 +43,7 @@ impl Config {
             self.default_path = Some(env::current_dir()?.canonicalize()?);
         }
         if self.display_mode.is_none() {
-            self.display_mode = Some(DisplayMode::Classic)
+            self.display_mode = Some(DisplayMode::Standard)
         }
         Ok(())
     }
@@ -51,5 +51,13 @@ impl Config {
     pub fn print(self) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&self)?);
         Ok(())
+    }
+
+    pub fn determine_display_mode(&self) -> Result<DisplayMode> {
+        match self.display_mode {
+            Some(DisplayMode::Standard) => Ok(DisplayMode::Standard),
+            Some(DisplayMode::Classic) => Ok(DisplayMode::Classic),
+            None => Err(Error::EmptyConfigOption(self.to_owned()).into()),
+        }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -71,7 +71,7 @@ pub fn standard(reports: &Reports) -> Result<()> {
             }
             false => println!(),
         }
-    
+
         print!("📡 ");
         let full_path = Path::new(&report.parent).join(&report.path);
         color::write_group_title(&format!(
@@ -79,7 +79,7 @@ pub fn standard(reports: &Reports) -> Result<()> {
             &report.path,
             full_path
                 .to_str()
-                .ok_or(Error::PathToStrConversionFailure(full_path.clone()))?
+                .ok_or_else(|| Error::PathToStrConversionFailure(full_path.clone()))?
         ))?;
         color::write_status(&report.status, &report.status_as_string, PAD)?;
         println!(

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,10 +1,10 @@
+use crate::color;
+use crate::error::Error;
+use crate::report::{Reports, NONE};
+use anyhow::Result;
 use std::path::Path;
 
-use crate::color;
-use crate::report::Reports;
-use anyhow::Result;
-
-pub const PAD: usize = 2;
+const PAD: usize = 2;
 
 pub fn classic(reports: &Reports) -> Result<()> {
     let length = reports.0.keys().len();
@@ -43,7 +43,7 @@ pub fn classic(reports: &Reports) -> Result<()> {
 
         for report in reports {
             print!("{:<path_width$}", report.path, path_width = path_max + PAD);
-            color::write_status(&report.status, status_max + PAD)?;
+            color::write_status(&report.status, &report.status_as_string, status_max + PAD)?;
             println!(
                 "{:<branch_width$}{}",
                 report.branch,
@@ -55,12 +55,44 @@ pub fn classic(reports: &Reports) -> Result<()> {
     Ok(())
 }
 
-// TODO: finish this functionality.
-pub fn modern(reports: &Reports) -> Result<()> {
-    for i in &reports.0 {
-        for i in i.1 {
-            println!("{:?}", Path::new(&i.parent).join(&i.path));
+pub fn standard(reports: &Reports) -> Result<()> {
+    let mut all_reports = Vec::new();
+    for grouped_report in &reports.0 {
+        all_reports.append(&mut grouped_report.1.clone());
+    }
+    all_reports.sort_by(|a, b| a.path.cmp(&b.path));
+    all_reports.sort_by(|a, b| a.status_as_string.cmp(&b.status_as_string));
+
+    let mut first = true;
+    for report in all_reports {
+        match first {
+            true => {
+                first = false;
+            }
+            false => println!(),
         }
+    
+        print!("📡 ");
+        let full_path = Path::new(&report.parent).join(&report.path);
+        color::write_group_title(&format!(
+            "{} ⇒ {}",
+            &report.path,
+            full_path
+                .to_str()
+                .ok_or(Error::PathToStrConversionFailure(full_path.clone()))?
+        ))?;
+        color::write_status(&report.status, &report.status_as_string, PAD)?;
+        println!(
+            " ({})
+{}
+{}",
+            report.branch,
+            report.url,
+            match &report.email {
+                Some(s) => s,
+                None => NONE,
+            },
+        );
     }
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use crate::config::Config;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -12,8 +11,6 @@ pub enum Error {
     FileNameStrConversionFailure(PathBuf),
     #[error("could not convert path (Path) to &str: {0}")]
     PathToStrConversionFailure(PathBuf),
-    #[error("found empty option in config: {0:?}")]
-    EmptyConfigOption(Config),
     #[error("could not find home directory")]
     HomeDirNotFound,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,34 +18,33 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::config::EntryConfig;
     use crate::error::Error;
     use std::env;
 
     #[test]
     fn current_directory() {
-        let mut config = Config::default();
-        config.set_defaults_if_empty().unwrap();
+        let config = config::entry_config_to_config(&EntryConfig::default()).unwrap();
 
         assert!(run::run(&config).is_ok());
     }
 
     #[test]
     fn parent_directory() {
-        let mut config = Config::default();
-        config.set_defaults_if_empty().unwrap();
+        let mut config = config::entry_config_to_config(&EntryConfig::default()).unwrap();
+
         let mut parent = env::current_dir().expect("failed to get current working directory");
         parent.pop();
-        config.default_path = Some(parent);
+        config.path = parent;
 
         assert!(run::run(&config).is_ok());
     }
 
     #[test]
     fn home_directory() {
-        let mut config = Config::default();
-        config.set_defaults_if_empty().unwrap();
-        config.default_path = Some(dirs::home_dir().ok_or(Error::HomeDirNotFound).unwrap());
+        let mut config = config::entry_config_to_config(&EntryConfig::default()).unwrap();
+
+        config.path = dirs::home_dir().ok_or(Error::HomeDirNotFound).unwrap();
 
         assert!(run::run(&config).is_ok());
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,22 +1,14 @@
 use crate::config::{Config, DisplayMode};
 use crate::display;
-use crate::error::Error;
+
 use crate::report::Reports;
 use crate::target_gen::Targets;
 use anyhow::Result;
 
 pub fn run(config: &Config) -> Result<()> {
-    let display_mode = config.determine_display_mode()?;
+    let reports = Reports::new(Targets::new(&config.path)?, &config.display_mode)?;
 
-    let reports = Reports::new(
-        Targets::new(match &config.default_path {
-            Some(s) => s,
-            None => return Err(Error::EmptyConfigOption(config.to_owned()).into()),
-        })?,
-        &display_mode,
-    )?;
-
-    match display_mode {
+    match config.display_mode {
         DisplayMode::Standard => display::standard(&reports),
         DisplayMode::Classic => display::classic(&reports),
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -6,13 +6,18 @@ use crate::target_gen::Targets;
 use anyhow::Result;
 
 pub fn run(config: &Config) -> Result<()> {
-    let reports = Reports::new(Targets::new(match &config.default_path {
-        Some(s) => s,
-        None => return Err(Error::EmptyConfigOption(config.to_owned()).into()),
-    })?)?;
-    match config.display_mode {
-        Some(DisplayMode::Modern) => display::modern(&reports),
-        Some(DisplayMode::Classic) => display::classic(&reports),
-        None => Err(Error::EmptyConfigOption(config.to_owned()).into()),
+    let display_mode = config.determine_display_mode()?;
+
+    let reports = Reports::new(
+        Targets::new(match &config.default_path {
+            Some(s) => s,
+            None => return Err(Error::EmptyConfigOption(config.to_owned()).into()),
+        })?,
+        &display_mode,
+    )?;
+
+    match display_mode {
+        DisplayMode::Standard => display::standard(&reports),
+        DisplayMode::Classic => display::classic(&reports),
     }
 }


### PR DESCRIPTION
## Commit 1: Finish standard display mode 

- Finish standard display mode and switch it to default
- Mode classic display mode behind new flag

## Commit 2: Split config into two config types 

- Split config into entry config and config
- Entry config is a reflection of config, but with all fields wrapped
  with option for serialization
- Replace "default" boilerplate conversions with impl on the true config
  type
