### PR TITLE
Update output to not use emojis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,18 +320,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa",
  "ryu",

--- a/README.md
+++ b/README.md
@@ -15,25 +15,22 @@
 
 ```
 % gfold
-📡 astrid ⇒ /home/neloth/src/astrid
-unclean (main)
-git@github.com:db/astrid.git
-neloth@housetelvanni.dev
-
-📡 fev ⇒ /home/neloth/src/fev
-bare (issue2277)
-none
-neloth@housetelvanni.dev
-
-📡 gb ⇒ /home/neloth/src/gb
-unpushed (dev)
-https://github.com/hrothgar/gb.git
-neloth@housetelvanni.dev
-
-📡 pam ⇒ /home/neloth/src/pam
-clean (main)
-https://github.com/onc/pam.git
-neloth@solstheimcommunityserver.org
+astrid ~ /home/neloth/src/astrid
+  unclean (main)
+  git@github.com:db/astrid.git
+  neloth@housetelvanni.dev
+fev ~ /home/neloth/src/fev
+  bare (issue2277)
+  none
+  neloth@housetelvanni.dev
+gb ~ /home/neloth/src/gb
+  unpushed (dev)
+  https://github.com/hrothgar/gb.git
+  neloth@housetelvanni.dev
+pam ~ /home/neloth/src/pam
+  clean (main)
+  https://github.com/onc/pam.git
+  neloth@solstheimcommunityserver.org
 ```
 
 The classic display mode can be toggled on with `--classic`.

--- a/src/color.rs
+++ b/src/color.rs
@@ -22,9 +22,24 @@ pub fn write_status(
     stdout.reset()
 }
 
-pub fn write_group_title(title: &str) -> io::Result<()> {
+pub fn write_bold(input: &str, newline: bool) -> io::Result<()> {
+    write_color(input, newline, ColorSpec::new().set_bold(true))
+}
+
+pub fn write_gray(input: &str, newline: bool) -> io::Result<()> {
+    write_color(
+        input,
+        newline,
+        ColorSpec::new().set_fg(Some(Color::Rgb(128, 128, 128))),
+    )
+}
+
+fn write_color(input: &str, newline: bool, color_spec: &mut ColorSpec) -> io::Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
-    stdout.set_color(ColorSpec::new().set_bold(true))?;
-    writeln!(&mut stdout, "{}", title)?;
+    stdout.set_color(color_spec)?;
+    match newline {
+        true => writeln!(&mut stdout, "{}", input)?,
+        false => write!(&mut stdout, "{}", input)?,
+    }
     stdout.reset()
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -19,7 +19,7 @@ pub fn classic(reports: &Reports) -> Result<()> {
                 }
                 false => println!(),
             }
-            color::write_group_title(group.0)?;
+            color::write_bold(group.0, true)?;
         }
 
         let mut path_max = 0;
@@ -64,29 +64,24 @@ pub fn standard(reports: &Reports) -> Result<()> {
     all_reports.sort_by(|a, b| a.path.cmp(&b.path));
     all_reports.sort_by(|a, b| a.status_as_string.cmp(&b.status_as_string));
 
-    let mut first = true;
     for report in all_reports {
-        match first {
-            true => {
-                first = false;
-            }
-            false => println!(),
-        }
+        color::write_bold(&report.path, false)?;
 
-        print!("📡 ");
         let full_path = Path::new(&report.parent).join(&report.path);
-        color::write_group_title(&format!(
-            "{} ⇒ {}",
-            &report.path,
+        let full_path_formatted = format!(
+            " ~ {}",
             full_path
                 .to_str()
                 .ok_or_else(|| Error::PathToStrConversionFailure(full_path.clone()))?
-        ))?;
+        );
+        color::write_gray(&full_path_formatted, true)?;
+
+        print!("  ");
         color::write_status(&report.status, &report.status_as_string, PAD)?;
         println!(
             " ({})
-{}
-{}",
+  {}
+  {}",
             report.branch,
             report.url,
             match &report.email {


### PR DESCRIPTION
- Avoid emoji use for compatability
- Print grey for full paths in standard output
- Update README example with changes
