### PR TITLE
Use git2-rs over git subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- The latest version contains all changes. -->
 
+### Added
+
+- [git2-rs](https://github.com/rust-lang/git2-rs), which replaces `git` subcommand usage
+
 ### Changed
 
 - Major performance improvements due to moving from sequential target generation to nested, parallel iterators for target generation
+
+### Removed
+
+- Git path option for CLI and config file
+- `git` subcommand usage
+
+### Notes
+
+- Even though `git` subcommands were used over **git2-rs** to reduce binary size, significant speed increases could only be achieved by using the latter.
+- Technically, removing the Git path option from the CLI and the config file could require a major version increase.
+- Given the immaturity of `3.0.0`, the (likely) infrequent use of the Git path option, and the overall structure/behavior remaining intact, the removal of this config option only necessitates a minor version increase.
+- For technical details on the field removal, please refer to the [diff between releases](https://github.com/nickgerace/gfold/compare/3.0.0...3.1.0).
 
 ### [3.0.0] - 2022-01-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,12 +185,26 @@ dependencies = [
  "argh",
  "dirs",
  "env_logger",
+ "git2",
  "log",
  "rayon",
  "serde",
  "serde_json",
  "termcolor",
  "thiserror",
+]
+
+[[package]]
+name = "git2"
+version = "0.13.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -199,10 +232,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -217,6 +270,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.26+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +301,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memoffset"
@@ -243,6 +326,18 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "proc-macro2"
@@ -340,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa",
  "ryu",
@@ -351,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -390,6 +485,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +525,24 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.56.1"
 anyhow = "1"
 argh = "0"
 dirs = "4"
+git2 = { version = "0", default_features = false }
 log = "0"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ By default, `gfold` looks at every Git repository via traversal from the current
 If you would like to target another directory, you can pass its path (relative or absolute) as the first argument or change the default path in the config file.
 
 After traversal, `gfold` leverages [rayon](https://github.com/rayon-rs/rayon) to perform concurrent, read-only analysis of all Git repositories detected.
-Analysis is performed with the `git` CLI rather than [libgit2](https://github.com/rust-lang/git2-rs) to reduce binary size.
+Analysis is performed by leveraging the [git2-rs](https://github.com/rust-lang/git2-rs) library.
 
 ## Usage
 
@@ -96,7 +96,6 @@ Here are the contents of the resulting config file:
 {
   "path": "/home/neloth",
   "display_mode": "Classic",
-  "git_path": null
 }
 ```
 

--- a/scripts/bench-loosely.sh
+++ b/scripts/bench-loosely.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 if [ "$REPOPATH" = "" ]; then
     echo "must execute script via make target from repository root"
     exit 1
@@ -10,13 +12,17 @@ OLD=$(which gfold)
 NEW=$REPOPATH/target/release/gfold
 
 function run {
-	echo "============================================================="
-	time $OLD $1
-	echo "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"
-	time $NEW -i $1
-	echo "============================================================="
+  for COUNT in {1..4}; do
+    echo "
+
+
+$1 $COUNT
+"
+    time $OLD $1
+    echo "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"
+    time $NEW -i $1
+  done
 }
 
-run "/"
 run "$HOME/"
 run "$HOME/src"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,6 @@ use crate::{logging, run};
 use anyhow::Result;
 use argh::FromArgs;
 use std::env;
-use std::path::PathBuf;
 
 #[derive(FromArgs)]
 #[argh(description = "More information: https://github.com/nickgerace/gfold
@@ -36,11 +35,6 @@ struct Args {
         description = "enable debug logging (sets \"RUST_LOG\" to \"debug\")"
     )]
     debug: bool,
-    #[argh(
-        option,
-        description = "specify path to git binary rather than using git in PATH"
-    )]
-    git_path: Option<PathBuf>,
     #[argh(switch, short = 'i', description = "ignore config file settings")]
     ignore_config_file: bool,
     #[argh(
@@ -76,9 +70,6 @@ fn merge_config_and_run(args: &Args) -> Result<()> {
     }
     if args.classic {
         config.display_mode = DisplayMode::Classic;
-    }
-    if let Some(s) = &args.git_path {
-        config.git_path = Some(s.clone());
     }
 
     match args.print {

--- a/src/color.rs
+++ b/src/color.rs
@@ -2,11 +2,7 @@ use crate::status::Status;
 use std::io::{self, Write};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-pub fn write_status(
-    status: &Status,
-    status_as_string: &str,
-    status_width: usize,
-) -> io::Result<()> {
+pub fn write_status(status: &Status, status_width: usize) -> io::Result<()> {
     let mut stdout = StandardStream::stdout(ColorChoice::Always);
     stdout.set_color(ColorSpec::new().set_fg(Some(match status {
         Status::Bare => Color::Red,
@@ -16,7 +12,7 @@ pub fn write_status(
     write!(
         &mut stdout,
         "{:<status_width$}",
-        status_as_string,
+        status.as_str(),
         status_width = status_width,
     )?;
     stdout.reset()

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ use std::path::PathBuf;
 pub struct Config {
     pub path: PathBuf,
     pub display_mode: DisplayMode,
-    pub git_path: Option<PathBuf>,
 }
 
 // "EntryConfig" is a reflection of "Config" with its fields wrapped as "Option" types. This is to
@@ -26,7 +25,6 @@ pub struct Config {
 struct EntryConfig {
     pub path: Option<PathBuf>,
     pub display_mode: Option<DisplayMode>,
-    pub git_path: Option<PathBuf>,
 }
 
 // "DisplayMode" dictates which way the results gathered should be displayed to the user via
@@ -93,7 +91,6 @@ impl Config {
                 Some(s) => s.clone(),
                 None => DisplayMode::Standard,
             },
-            git_path: entry_config.git_path.clone(),
         })
     }
 }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,1 +1,0 @@
-pub const NONE: &str = "none";

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,16 +1,17 @@
 use crate::color;
-use crate::consts::NONE;
 use crate::error::Error;
 use crate::report::Reports;
 use anyhow::Result;
+use log::warn;
 use std::path::Path;
 
 const PAD: usize = 2;
+const NONE: &str = "none";
 
 pub fn classic(reports: &Reports) -> Result<()> {
     let length = reports.keys().len();
     let mut first = true;
-    for group in reports {
+    for (title, group) in reports {
         // FIXME: make group title matching less cumbersome.
         if length > 1 {
             match first {
@@ -19,17 +20,23 @@ pub fn classic(reports: &Reports) -> Result<()> {
                 }
                 false => println!(),
             }
-            color::write_bold(group.0, true)?;
+            color::write_bold(
+                match title {
+                    Some(s) => s,
+                    None => NONE,
+                },
+                true,
+            )?;
         }
 
         let mut path_max = 0;
         let mut branch_max = 0;
         let mut status_max = 0;
-        for report in group.1 {
+        for report in group {
             if report.path.len() > path_max {
                 path_max = report.path.len();
             }
-            let status_length = report.status_as_string.len();
+            let status_length = report.status.as_str().len();
             if status_length > status_max {
                 status_max = status_length;
             }
@@ -38,17 +45,20 @@ pub fn classic(reports: &Reports) -> Result<()> {
             }
         }
 
-        let mut reports = group.1.clone();
+        let mut reports = group.clone();
         reports.sort_by(|a, b| a.path.cmp(&b.path));
-        reports.sort_by(|a, b| a.status_as_string.cmp(&b.status_as_string));
+        reports.sort_by(|a, b| a.status.as_str().cmp(b.status.as_str()));
 
         for report in reports {
             print!("{:<path_width$}", report.path, path_width = path_max + PAD);
-            color::write_status(&report.status, &report.status_as_string, status_max + PAD)?;
+            color::write_status(&report.status, status_max + PAD)?;
             println!(
                 "{:<branch_width$}{}",
                 report.branch,
-                report.url,
+                match &report.url {
+                    Some(s) => s,
+                    None => NONE,
+                },
                 branch_width = branch_max + PAD
             );
         }
@@ -62,12 +72,19 @@ pub fn standard(reports: &Reports) -> Result<()> {
         all_reports.append(&mut grouped_report.1.clone());
     }
     all_reports.sort_by(|a, b| a.path.cmp(&b.path));
-    all_reports.sort_by(|a, b| a.status_as_string.cmp(&b.status_as_string));
+    all_reports.sort_by(|a, b| a.status.as_str().cmp(b.status.as_str()));
 
     for report in all_reports {
         color::write_bold(&report.path, false)?;
 
-        let full_path = Path::new(&report.parent).join(&report.path);
+        let parent = match report.parent {
+            Some(s) => s,
+            None => {
+                warn!("parent is empty for report: {}", report.path);
+                continue;
+            }
+        };
+        let full_path = Path::new(&parent).join(&report.path);
         let full_path_formatted = format!(
             " ~ {}",
             full_path
@@ -77,13 +94,16 @@ pub fn standard(reports: &Reports) -> Result<()> {
         color::write_gray(&full_path_formatted, true)?;
 
         print!("  ");
-        color::write_status(&report.status, &report.status_as_string, PAD)?;
+        color::write_status(&report.status, PAD)?;
         println!(
             " ({})
   {}
   {}",
             report.branch,
-            report.url,
+            match &report.url {
+                Some(s) => s,
+                None => NONE,
+            },
             match &report.email {
                 Some(s) => s,
                 None => NONE,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("could not strip newline from String: {0}")]
-    StripNewLineFromStringFailure(String),
     #[error("received None (Option<&OsStr>) for file name: {0}")]
     FileNameNotFound(PathBuf),
     #[error("could not convert file name (&OsStr) to &str: {0}")]
@@ -13,4 +11,6 @@ pub enum Error {
     PathToStrConversionFailure(PathBuf),
     #[error("could not find home directory")]
     HomeDirNotFound,
+    #[error("full shorthand for Git reference is invalid UTF-8")]
+    GitReferenceShorthandInvalid,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use anyhow::Result;
 mod cli;
 mod color;
 mod config;
-mod consts;
 mod display;
 mod error;
 mod logging;

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,224 +1,107 @@
 use crate::config::DisplayMode;
-use crate::consts::NONE;
 use crate::error::Error;
 use crate::status::Status;
 use anyhow::Result;
-use log::{debug, error, warn};
+use git2::{Config, ErrorCode, Reference, Repository, StatusOptions};
+use log::{debug, error, trace, warn};
 use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::{fs, io};
 
-#[cfg(target_os = "windows")]
-const NEWLINE: &str = "\r\n";
-#[cfg(not(target_os = "windows"))]
-const NEWLINE: &str = "\n";
-
 // Use a BTreeMap over a HashMap for sorted keys.
-pub type Reports = BTreeMap<String, Vec<Report>>;
+pub type Reports = BTreeMap<Option<String>, Vec<Report>>;
 
 #[derive(Clone, Debug)]
 pub struct Report {
     pub path: String,
-    pub parent: String,
-    pub status: Status,
-    pub status_as_string: String,
     pub branch: String,
-    pub url: String,
+    pub status: Status,
+
+    // Fields that can report NONE with impeding execution.
+    pub parent: Option<String>,
+    pub url: Option<String>,
 
     // Optional field that's only used in DisplayMode::Standard.
     pub email: Option<String>,
 }
 
-pub fn generate_reports(
-    path: &Path,
-    display_mode: &DisplayMode,
-    git_path: &Option<PathBuf>,
-) -> Result<Reports> {
-    let include_email = match display_mode {
-        DisplayMode::Standard => true,
-        DisplayMode::Classic => false,
-    };
-    let git_path = match git_path {
-        Some(s) => s.canonicalize()?,
-        None => Path::new("git").to_path_buf(),
-    };
+impl Report {
+    pub fn new(
+        path: &str,
+        branch: &str,
+        status: &Status,
+        parent: Option<String>,
+        url: Option<String>,
+        email: Option<String>,
+    ) -> Self {
+        Self {
+            path: (*path).into(),
+            branch: (*branch).into(),
+            status: *status,
+            parent,
+            url,
+            email,
+        }
+    }
 
-    let unprocessed = recursive_target_gen(path)?
-        .into_par_iter()
-        .map(|path| generate_report(&path, &git_path, include_email))
-        .collect::<Vec<Result<Report>>>();
+    pub fn generate_reports(path: &Path, display_mode: &DisplayMode) -> Result<Reports> {
+        let include_email = match display_mode {
+            DisplayMode::Standard => true,
+            DisplayMode::Classic => false,
+        };
 
-    let mut processed = Reports::new();
-    for wrapped_report in unprocessed {
-        match wrapped_report {
-            Ok(o) => {
-                let report = o.clone();
-                if let Some(mut s) = processed.insert(report.clone().parent, vec![report.clone()]) {
-                    s.push(report.clone());
-                    processed.insert(report.parent, s);
+        let unprocessed = recursive_target_gen(path)?
+            .par_iter()
+            .map(|path| generate_report(path, include_email))
+            .collect::<Vec<Result<Report>>>();
+
+        let mut processed = Reports::new();
+        for wrapped_report in unprocessed {
+            match wrapped_report {
+                Ok(report) => {
+                    if let Some(mut v) =
+                        processed.insert(report.parent.clone(), vec![report.clone()])
+                    {
+                        v.push(report.clone());
+                        processed.insert(report.parent, v);
+                    }
                 }
+                Err(e) => return Err(e),
             }
-            Err(e) => return Err(e),
         }
-    }
-    Ok(processed)
-}
-
-fn generate_report(repo_path: &Path, git_path: &Path, include_email: bool) -> Result<Report> {
-    let git_shim = GitShim {
-        working_directory: repo_path.to_path_buf(),
-        git_path: git_path.to_path_buf(),
-    };
-    let branch = git_shim.get_branch()?;
-    let status = match git_shim.is_bare()? {
-        true => Status::Bare,
-        false => match git_shim.is_unclean()? {
-            true => Status::Unclean,
-            false => match git_shim.is_unpushed(&branch)? {
-                true => Status::Unpushed,
-                false => Status::Clean,
-            },
-        },
-    };
-    let status_as_string = format!("{:?}", &status).to_lowercase();
-
-    debug!(
-        "generating report for repository at {:?} on branch {} with status: {:?}",
-        &repo_path, &branch, &status
-    );
-    Ok(Report {
-        path: match repo_path.file_name() {
-            Some(s) => match s.to_str() {
-                Some(s) => s.to_string(),
-                None => {
-                    return Err(Error::FileNameStrConversionFailure(repo_path.to_path_buf()).into())
-                }
-            },
-            None => return Err(Error::FileNameNotFound(repo_path.to_path_buf()).into()),
-        },
-        parent: match repo_path.parent() {
-            Some(s) => match s.to_str() {
-                Some(s) => s.to_string(),
-                None => return Err(Error::PathToStrConversionFailure(s.to_path_buf()).into()),
-            },
-            None => NONE.to_string(),
-        },
-        status,
-        status_as_string,
-        branch,
-        url: git_shim.get_url()?,
-        email: match include_email {
-            true => Some(git_shim.get_email()?),
-            false => None,
-        },
-    })
-}
-
-struct GitShim {
-    working_directory: PathBuf,
-    git_path: PathBuf,
-}
-
-impl GitShim {
-    pub fn is_bare(&self) -> Result<bool> {
-        let bare_output = self.git(&["rev-parse", "--is-bare-repository"])?;
-        match bare_output.strip_suffix(NEWLINE) {
-            Some(s) => Ok(s != "false"),
-            None => Err(Error::StripNewLineFromStringFailure(bare_output).into()),
-        }
-    }
-
-    pub fn is_unclean(&self) -> Result<bool> {
-        Ok(!self.git(&["status", "--porcelain"])?.is_empty())
-    }
-
-    pub fn is_unpushed(&self, branch: &str) -> Result<bool> {
-        Ok(!self
-            .git(&["log", &format!("origin/{}..HEAD", branch)])?
-            .is_empty())
-    }
-
-    pub fn get_branch(&self) -> Result<String> {
-        let branch = self.git(&["rev-parse", "--abbrev-ref", "HEAD"])?;
-        match branch.strip_suffix(NEWLINE) {
-            Some(s) => Ok(s.to_string()),
-            None => Err(Error::StripNewLineFromStringFailure(branch).into()),
-        }
-    }
-
-    pub fn get_email(&self) -> Result<String> {
-        Ok(
-            match self
-                .git(&["config", "--get", "user.email"])?
-                .strip_suffix(NEWLINE)
-            {
-                Some(s) => s.to_string(),
-                None => NONE.to_string(),
-            },
-        )
-    }
-
-    pub fn get_url(&self) -> Result<String> {
-        Ok(
-            match self
-                .git(&["config", "--get", "remote.origin.url"])?
-                .strip_suffix(NEWLINE)
-            {
-                Some(s) => s.to_string(),
-                None => NONE.to_string(),
-            },
-        )
-    }
-
-    fn git(&self, args: &[&str]) -> Result<String> {
-        let output = Command::new(&self.git_path)
-            .args(args)
-            .current_dir(&self.working_directory)
-            .output()?;
-        debug!(
-            "executed {:?} in {:?} with args {:?}: {:?}",
-            &self.git_path, &self.working_directory, args, output
-        );
-        Ok(String::from_utf8(output.stdout)?)
+        Ok(processed)
     }
 }
 
-fn recursive_target_gen(path: &Path) -> Result<Vec<PathBuf>> {
-    let mut results = vec![];
+type Target = io::Result<Option<Vec<PathBuf>>>;
+
+fn recursive_target_gen(path: &Path) -> io::Result<Vec<PathBuf>> {
     let entries: Vec<DirEntry> = match fs::read_dir(&path) {
         Ok(o) => o.filter_map(|r| r.ok()).collect(),
         Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
             warn!("{}: {}", e, &path.display());
-            return Ok(results);
+            return Ok(vec![]);
         }
         Err(e) => {
             error!("{}: {}", e, &path.display());
-            return Ok(results);
+            return Ok(vec![]);
         }
     };
 
     let targets = entries
         .par_iter()
-        .map(|entry| {
-            if entry.file_type()?.is_dir() && !is_hidden(entry) {
-                return match has_git_subdir(entry) {
-                    true => Ok(Some(vec![entry.path()])),
-                    false => Ok(Some(recursive_target_gen(&entry.path())?)),
-                };
-            }
-            Ok(None)
-        })
-        .collect::<Vec<Result<Option<Vec<PathBuf>>>>>();
+        .map(process_entry)
+        .collect::<Vec<Target>>();
 
+    let mut results = vec![];
     for target in targets {
         match target {
-            Ok(o) => {
-                if let Some(mut s) = o {
-                    if !s.is_empty() {
-                        results.append(&mut s);
+            Ok(v) => {
+                if let Some(mut v) = v {
+                    if !v.is_empty() {
+                        results.append(&mut v);
                     }
                 }
             }
@@ -228,15 +111,131 @@ fn recursive_target_gen(path: &Path) -> Result<Vec<PathBuf>> {
     Ok(results)
 }
 
-fn is_hidden(entry: &DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .map(|s| s.starts_with('.'))
-        .unwrap_or(false)
+// Ensure the entry is a directory and is not hidden. Then, check if a Git sub directory exists,
+// which will indicate if the entry is a repository. Finally, generate targets based on that
+// repository.
+fn process_entry(entry: &DirEntry) -> Target {
+    match entry.file_type()?.is_dir()
+        && !entry
+            .file_name()
+            .to_str()
+            .map(|file_name| file_name.starts_with('.'))
+            .unwrap_or(false)
+    {
+        true => {
+            let path = entry.path();
+            let git_sub_directory = path.join(".git");
+            match git_sub_directory.exists() && git_sub_directory.is_dir() {
+                true => Ok(Some(vec![path])),
+                false => Ok(Some(recursive_target_gen(&path)?)),
+            }
+        }
+        false => Ok(None),
+    }
 }
 
-fn has_git_subdir(entry: &DirEntry) -> bool {
-    let suspect = entry.path().join(".git");
-    suspect.exists() && suspect.is_dir()
+fn generate_report(repo_path: &Path, include_email: bool) -> Result<Report> {
+    let repo = Repository::open(repo_path)?;
+    let head = repo.head()?;
+    let branch = head
+        .shorthand()
+        .ok_or(Error::GitReferenceShorthandInvalid)?;
+
+    let mut opts = StatusOptions::new();
+    let status = match repo.statuses(Some(&mut opts)) {
+        Ok(v) if v.is_empty() => match is_unpushed(&repo, &head)? {
+            true => Status::Unpushed,
+            false => Status::Clean,
+        },
+        Ok(_) => Status::Unclean,
+        Err(e) if e.code() == ErrorCode::BareRepo => Status::Bare,
+        Err(e) => return Err(e.into()),
+    };
+
+    debug!(
+        "generating report for repository at {:?} on branch {} with status: {:?}",
+        &repo_path, &branch, &status
+    );
+    let origin = repo.find_remote("origin")?;
+    Ok(Report::new(
+        match repo_path.file_name() {
+            Some(s) => s
+                .to_str()
+                .ok_or_else(|| Error::FileNameStrConversionFailure(repo_path.to_path_buf()))?,
+            None => return Err(Error::FileNameNotFound(repo_path.to_path_buf()).into()),
+        },
+        branch,
+        &status,
+        match repo_path.parent() {
+            Some(s) => match s.to_str() {
+                Some(s) => Some(s.to_string()),
+                None => return Err(Error::PathToStrConversionFailure(s.to_path_buf()).into()),
+            },
+            None => None,
+        },
+        origin.url().map(|s| s.to_string()),
+        match include_email {
+            true => match get_email(Some(&repo_path.join(".git").join("config"))) {
+                Some(email) => Some(email),
+                None => get_email(None),
+            },
+            false => None,
+        },
+    ))
+}
+
+fn is_unpushed(repo: &Repository, head: &Reference) -> Result<bool> {
+    let local_head = head.peel_to_commit()?;
+    let remote = format!(
+        "origin/{}",
+        head.shorthand()
+            .ok_or(Error::GitReferenceShorthandInvalid)?
+    );
+    let remote_head = repo
+        .resolve_reference_from_short_name(&remote)?
+        .peel_to_commit()?;
+    Ok(
+        matches!(repo.graph_ahead_behind(local_head.id(), remote_head.id()), Ok(number_unique_commits) if number_unique_commits.0 > 0),
+    )
+}
+
+// Find the "user.email" value for a Git config. If a path is provided, try to open the config at
+// that path. Otherwise, try the default global Git config. Absorb and log any and all errors
+// as the email field is non-critical to our final results.
+fn get_email(config_path: Option<&Path>) -> Option<String> {
+    let config = match config_path {
+        Some(v) => Config::open(v),
+        None => Config::open_default(),
+    };
+    let config = match config {
+        Ok(v) => v,
+        Err(e) => {
+            trace!("ignored error: {}", e);
+            return None;
+        }
+    };
+    let entries = match config.entries(None) {
+        Ok(v) => v,
+        Err(e) => {
+            trace!("ignored error: {}", e);
+            return None;
+        }
+    };
+
+    // Greedily find our "user.email" value. Return the first result found.
+    for entry in &entries {
+        match entry {
+            Ok(entry) => {
+                if let Some(name) = entry.name() {
+                    if name == "user.email" {
+                        if let Some(value) = entry.value() {
+                            return Some(value.to_string());
+                        }
+                    }
+                }
+            }
+            Err(e) => debug!("ignored error: {}", e),
+        }
+    }
+    None
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,12 +1,13 @@
 use crate::config::{Config, DisplayMode};
-use crate::{display, report};
+use crate::display;
+use crate::report::Report;
 use anyhow::Result;
 
 // This function is the primary entrypoint for the crate. It takes a given config and performs
 // the end-to-end workflow using it. At this point, all CLI and config file options should be
 // set, merged, ignored, etc.
 pub fn run(config: &Config) -> Result<()> {
-    let reports = report::generate_reports(&config.path, &config.display_mode, &config.git_path)?;
+    let reports = Report::generate_reports(&config.path, &config.display_mode)?;
     match config.display_mode {
         DisplayMode::Standard => display::standard(&reports),
         DisplayMode::Classic => display::classic(&reports),

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,7 +1,18 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Status {
     Bare,
     Clean,
     Unclean,
     Unpushed,
+}
+
+impl Status {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Bare => "bare",
+            Self::Clean => "clean",
+            Self::Unclean => "unclean",
+            Self::Unpushed => "unpushed",
+        }
+    }
 }


### PR DESCRIPTION
- Use git2-rs over git subcommands for speed gains
- Use Option types over "none" or "-" strings for results
  - Ensure the display module handles how to display results
- Display status enum as string rather than carrying it as a field
- Remove git path from CLI and config file due to switch to git2-rs