### PR TITLE
Assume unpushed if unable to resolve ref from short name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,10 @@ name: ci
 on:
   push:
     branches:
-      - staging
-      - trying
+      - "main"
   pull_request:
     branches:
-      - main
+      - "main"
     paths:
       - "**.rs"
       - "Cargo.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,19 @@ For new changes prior to version 4.0.0, please see [CHANGELOG_PRE_V4](./docs/CHA
 
 ## Unreleased
 
-The latest version contains all changes.
+<!-- The latest version contains all changes. -->
+
+### Changed
+
+- Bump dependencies
+- When checking if unpushed and attempting to resolve the reference from a short name, ignore the error and assume we need to push
 
 ## 4.1.1 - 2022-12-19
 
 ### Changed
 
+- Bump dependencies
 - Ensure dependencies have their minor version fields locked
-- Update dependencies
 
 ### Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +283,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
  "termcolor",
  "thiserror",
  "toml",
@@ -339,6 +349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
@@ -446,11 +465,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -593,6 +612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +705,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![latest release tag](https://img.shields.io/github/v/tag/nickgerace/gfold?sort=semver&logo=git&logoColor=white&label=version&style=flat-square&color=blue)](https://github.com/nickgerace/gfold/releases/latest)
 [![crates.io version](https://img.shields.io/crates/v/gfold?style=flat-square&logo=rust&color=orange)](https://crates.io/crates/gfold)
 [![license](https://img.shields.io/github/license/nickgerace/gfold?style=flat-square&logo=apache&color=silver)](./LICENSE)
-[![build status](https://img.shields.io/github/workflow/status/nickgerace/gfold/merge/main?style=flat-square&logo=github&logoColor=white)](https://github.com/nickgerace/gfold/actions?query=workflow%3Amerge+branch%3Amain)
-[![bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/42509)
+[![build status](https://img.shields.io/github/actions/workflow/status/nickgerace/gfold/workflows/ci.yml?branch=main&style=flat-square&logo=github&logoColor=white)](https://img.shields.io/github/actions/workflow/status/nickgerace/gfold/workflows/ci.yml?branch=main&style=flat-square&logo=github&logoColor=white)
 
 `gfold` is a CLI-driven application that helps you keep track of multiple Git repositories.
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,0 @@
-status = [
-    "Lint / Test / Build (ubuntu-latest)",
-    "Test / Build (windows-latest)",
-    "Test / Build (macos-latest)"
-]
-timeout_sec = 900
-delete_merged_branches = true
-update_base_for_deletes	= true

--- a/crates/bench-loosely/Cargo.toml
+++ b/crates/bench-loosely/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dirs = "4"
+dirs = "4.0"

--- a/crates/gfold/Cargo.toml
+++ b/crates/gfold/Cargo.toml
@@ -31,3 +31,4 @@ env_logger = { version = "0.9", features = ["atty", "humantime"], default_featur
 
 [dev-dependencies]
 pretty_assertions = "1.3"
+tempfile = "3.3"

--- a/crates/gfold/src/cli.rs
+++ b/crates/gfold/src/cli.rs
@@ -65,7 +65,7 @@ pub fn parse_and_run() -> anyhow::Result<()> {
     debug!("collected args");
 
     let mut config = match cli.ignore_config_file {
-        true => Config::new()?,
+        true => Config::try_config_default()?,
         false => Config::try_config()?,
     };
     debug!("loaded initial config");

--- a/crates/gfold/src/config.rs
+++ b/crates/gfold/src/config.rs
@@ -86,8 +86,8 @@ impl Config {
     }
 
     /// This method does not look for the config file and uses [`EntryConfig`]'s defaults instead.
-    /// It is best for testing use and when the user wishes to skip config file lookup.
-    pub fn new() -> io::Result<Self> {
+    /// Use this method when the user wishes to skip config file lookup.
+    pub fn try_config_default() -> io::Result<Self> {
         Self::from_entry_config(&EntryConfig::default())
     }
 

--- a/crates/size/Cargo.toml
+++ b/crates/size/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dirs = "4"
+dirs = "4.0"


### PR DESCRIPTION
The behavior identified in #202 occurs because the constructed remote name (`<remote>/<local-branch-name>`) is assumed to exist. This will not always be the case, and will never (likely?) be the case when working on `HEAD`.

Closes #202
Closes #213