### PR TITLE
Ignore "extensions.worktreeconfig" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ For new changes prior to version 4.0.0, please see [CHANGELOG_PRE_V4](./docs/CHA
 
 ## Unreleased
 
-The latest version contains all changes.
+<!-- The latest version contains all changes. -->
+
+### Changed
+
+- Add "unknown" status for repositories hitting the "extensions.worktreeconfig" error
+- Bump dependencies
+- Change "unpushed" color to blue
+- Ignore the "extensions.worktreeconfig" error until the corresponding upstream issue is resolved: https://github.com/libgit2/libgit2/issues/6044
 
 ## 4.1.2 - 2022-12-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "656ad1e55e23d287773f7d8192c300dc715c3eeded93b3da651d11c42cfd74d2"
 dependencies = [
  "bitflags",
  "clap_derive",

--- a/crates/gfold/src/cli.rs
+++ b/crates/gfold/src/cli.rs
@@ -1,12 +1,13 @@
 //! This module contains the CLI entrypoint, CLI options and config generation based on the user's
 //! settings and environment.
 
-use crate::config::{ColorMode, Config, DisplayMode};
-use crate::error::Error;
-use crate::run;
 use clap::Parser;
 use log::debug;
 use std::env;
+
+use crate::config::{ColorMode, Config, DisplayMode};
+use crate::error::Error;
+use crate::run;
 
 const HELP: &str = "\
 More information: https://github.com/nickgerace/gfold

--- a/crates/gfold/src/config.rs
+++ b/crates/gfold/src/config.rs
@@ -1,9 +1,10 @@
 //! This module contains the config specification and functionality for creating a config.
 
-use crate::error::Error;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{env, fs, io};
+
+use crate::error::Error;
 
 /// This struct is the actual config type consumed through the codebase. It is boostrapped via its
 /// public methods and uses [`EntryConfig`], a private struct, under the hood in order to

--- a/crates/gfold/src/display.rs
+++ b/crates/gfold/src/display.rs
@@ -1,13 +1,14 @@
 //! This module contains the functionality for displaying reports to `stdout`.
 
-use crate::config::{ColorMode, DisplayMode};
-use crate::display::color::ColorHarness;
-use crate::error::Error;
-use crate::report::LabeledReports;
 use log::debug;
 use log::warn;
 use std::io;
 use std::path::Path;
+
+use crate::config::{ColorMode, DisplayMode};
+use crate::display::color::ColorHarness;
+use crate::error::Error;
+use crate::report::LabeledReports;
 
 mod color;
 

--- a/crates/gfold/src/display/color.rs
+++ b/crates/gfold/src/display/color.rs
@@ -1,9 +1,10 @@
 //! This module provides a harness for non-trivial displays of information to `stdout`.
 
-use crate::config::ColorMode;
-use crate::status::Status;
 use std::io::{self, Write};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::config::ColorMode;
+use crate::status::Status;
 
 /// This harness provides methods to write to `stdout`. It maps the internal [`ColorMode`] type to
 /// our dependency's [`ColorChoice`] type due to discrepancies in behavior and naming.
@@ -26,9 +27,10 @@ impl ColorHarness {
     pub fn write_status(&self, status: &Status, status_width: usize) -> io::Result<()> {
         let mut stdout = StandardStream::stdout(self.color_choice);
         stdout.set_color(ColorSpec::new().set_fg(Some(match status {
-            Status::Bare => Color::Red,
+            Status::Bare | Status::Unknown => Color::Red,
             Status::Clean => Color::Green,
-            _ => Color::Yellow,
+            Status::Unpushed => Color::Blue,
+            Status::Unclean => Color::Yellow,
         })))?;
         write!(
             &mut stdout,

--- a/crates/gfold/src/status.rs
+++ b/crates/gfold/src/status.rs
@@ -8,6 +8,7 @@ pub enum Status {
     Bare,
     Clean,
     Unclean,
+    Unknown,
     Unpushed,
 }
 
@@ -17,6 +18,7 @@ impl Status {
             Self::Bare => "bare",
             Self::Clean => "clean",
             Self::Unclean => "unclean",
+            Self::Unknown => "unknown",
             Self::Unpushed => "unpushed",
         }
     }


### PR DESCRIPTION
## Primary Change

Ignore "extensions.worktreeconfig" error until the upstream issue is resolved and git2-rs receives the fix. Repositories that hit this error will return an "unknown" result for the time being.

Upstream issue: https://github.com/libgit2/libgit2/issues/6044
Tracking issue: #205 

## Secondary Change

Additionally, change "unpushed" results to use the color blue instead of yellow (#219).

Fixes #219