### PR TITLE
Solely use ubuntu-latest for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 jobs:
-  test:
-    name: "Lint / Test / Build (ubuntu-latest)"
+  ci:
+    name: "CI"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,24 +31,3 @@ jobs:
         with:
           command: xtask
           args: ci
-  build:
-    name: "Test / Build"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-targets --locked


### PR DESCRIPTION
Drop Windows and macOS from CI due to their long build times. Windows and macOS are still first class platforms for gfold, but running individual tests and builds for them in CI has not been valuable recently.