### PR TITLE
Refactor gfold CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ panic = "abort"
 anyhow = { version = "1.0", features = ["backtrace"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "5.0"
-env_logger = { version = "0.11", features = ["humantime"], default_features = false }
-git2 = { version = "0.18", default_features = false }
+env_logger = { version = "0.11", features = ["humantime"], default-features = false }
+git2 = { version = "0.18", default-features = false }
 log = "0.4"
 pretty_assertions = "1.4"
 rayon = "1.10"

--- a/bin/gfold/Cargo.toml
+++ b/bin/gfold/Cargo.toml
@@ -27,3 +27,8 @@ serde_json = { workspace = true }
 termcolor = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+module_name_repetitions = "allow"

--- a/bin/gfold/src/cli.rs
+++ b/bin/gfold/src/cli.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use libgfold::RepositoryCollector;
 use log::debug;
 use std::env;
-use thiserror::Error;
 
 use crate::config::{ColorMode, Config, DisplayMode};
 use crate::display::DisplayHarness;
@@ -31,39 +30,22 @@ Troubleshooting:
   \"RUST_BACKTRACE=1\"and \"RUST_LOG=debug\". You can adjust those variable's
   values to aid investigation.";
 
-#[remain::sorted]
-#[derive(Error, Debug)]
-pub enum CliError {
-    #[error("invalid color mode provided (exec \"--help\" for options): {0}")]
-    InvalidColorMode(String),
-    #[error("invalid display mode provided (exec \"--help\" for options): {0}")]
-    InvalidDisplayMode(String),
-}
-
 #[derive(Parser)]
 #[command(version, about = HELP, long_about = None)]
 struct Cli {
-    #[arg(help = "specify path to target directory (defaults to current working directory)")]
+    /// specify path to target directory (defaults to current working directory)
     path: Option<String>,
 
-    #[arg(
-        short,
-        long,
-        help = "specify color mode (options: [\"always\", \"compatibility\", \"never\"])"
-    )]
-    color_mode: Option<String>,
-    #[arg(
-        short,
-        long,
-        help = "specify display format (options: [\"standard\", \"standard-alphabetical\", \"json\", \"classic\", \"default\"])"
-    )]
-    display_mode: Option<String>,
-    #[arg(
-        long,
-        help = "display finalized config options and exit (merged options from an optional config file and command line arguments)"
-    )]
+    #[arg(short, long)]
+    color_mode: Option<ColorMode>,
+    #[arg(short, long)]
+    display_mode: Option<DisplayMode>,
+
+    /// display finalized config options and exit (merged options from an optional config file and command line arguments)
+    #[arg(long)]
     dry_run: bool,
-    #[arg(short, long, help = "ignore config file settings")]
+    /// ignore config file settings
+    #[arg(short, long)]
     ignore_config_file: bool,
 }
 
@@ -81,31 +63,19 @@ impl CliHarness {
 
     /// Merge configurations as needed, collect results and display them.
     pub fn run(&self) -> anyhow::Result<()> {
-        let mut config = match self.cli.ignore_config_file {
-            true => Config::try_config_default()?,
-            false => Config::try_config()?,
+        let mut config = if self.cli.ignore_config_file {
+            Config::try_config_default()?
+        } else {
+            Config::try_config()?
         };
         debug!("loaded initial config");
 
         if let Some(found_display_mode_raw) = &self.cli.display_mode {
-            config.display_mode = match DisplayMode::from_str(found_display_mode_raw.to_lowercase())
-            {
-                Some(found_display_mode) => found_display_mode,
-                None => {
-                    return Err(
-                        CliError::InvalidDisplayMode(found_display_mode_raw.to_string()).into(),
-                    );
-                }
-            }
+            config.display_mode = *found_display_mode_raw;
         }
 
         if let Some(found_color_mode) = &self.cli.color_mode {
-            config.color_mode = match found_color_mode.to_lowercase().as_str() {
-                "always" => ColorMode::Always,
-                "compatibility" => ColorMode::Compatibility,
-                "never" => ColorMode::Never,
-                _ => return Err(CliError::InvalidColorMode(found_color_mode.to_string()).into()),
-            }
+            config.color_mode = *found_color_mode;
         }
 
         if let Some(found_path) = &self.cli.path {
@@ -113,20 +83,19 @@ impl CliHarness {
         }
 
         debug!("finalized config options");
-        match &self.cli.dry_run {
-            true => config.print()?,
-            false => {
-                let (include_email, include_submodules) = match config.display_mode {
-                    DisplayMode::Classic => (false, false),
-                    DisplayMode::Json => (true, true),
-                    DisplayMode::Standard => (true, false),
-                    DisplayMode::StandardAlphabetical => (true, false),
-                };
-                let repository_collection =
-                    RepositoryCollector::run(&config.path, include_email, include_submodules)?;
-                let display_harness = DisplayHarness::new(config.display_mode, config.color_mode);
-                display_harness.run(&repository_collection)?;
-            }
+        if self.cli.dry_run {
+            config.print()?;
+        } else {
+            let (include_email, include_submodules) = match config.display_mode {
+                DisplayMode::Classic => (false, false),
+                DisplayMode::Json => (true, true),
+                DisplayMode::Standard => (true, false),
+                DisplayMode::StandardAlphabetical => (true, false),
+            };
+            let repository_collection =
+                RepositoryCollector::run(&config.path, include_email, include_submodules)?;
+            let display_harness = DisplayHarness::new(config.display_mode, config.color_mode);
+            display_harness.run(&repository_collection)?;
         }
         Ok(())
     }

--- a/bin/gfold/src/cli.rs
+++ b/bin/gfold/src/cli.rs
@@ -89,8 +89,7 @@ impl CliHarness {
             let (include_email, include_submodules) = match config.display_mode {
                 DisplayMode::Classic => (false, false),
                 DisplayMode::Json => (true, true),
-                DisplayMode::Standard => (true, false),
-                DisplayMode::StandardAlphabetical => (true, false),
+                DisplayMode::Standard | DisplayMode::StandardAlphabetical => (true, false),
             };
             let repository_collection =
                 RepositoryCollector::run(&config.path, include_email, include_submodules)?;

--- a/bin/gfold/src/config.rs
+++ b/bin/gfold/src/config.rs
@@ -1,5 +1,6 @@
 //! This module contains the config specification and functionality for creating a config.
 
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{env, fs, io};
@@ -101,7 +102,7 @@ struct EntryConfig {
 /// In summary, while this setting is primarily for cosmetics, it may also affect runtime
 /// performance based on what needs to be displayed.
 #[remain::sorted]
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Serialize, Deserialize, Clone, Copy, ValueEnum)]
 pub enum DisplayMode {
     /// Informs the caller to display results in the classic format.
     Classic,
@@ -115,21 +116,9 @@ pub enum DisplayMode {
     StandardAlphabetical,
 }
 
-impl DisplayMode {
-    pub fn from_str(input: impl AsRef<str>) -> Option<Self> {
-        match input.as_ref() {
-            "classic" => Some(Self::Classic),
-            "json" => Some(Self::Json),
-            "standard" | "default" => Some(Self::Standard),
-            "standard-alphabetical" => Some(Self::StandardAlphabetical),
-            _ => None,
-        }
-    }
-}
-
 /// Set the color mode of results printed to `stdout`.
 #[remain::sorted]
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Serialize, Deserialize, Clone, Copy, ValueEnum)]
 pub enum ColorMode {
     /// Attempt to display colors as intended (default behavior).
     Always,

--- a/bin/gfold/src/config.rs
+++ b/bin/gfold/src/config.rs
@@ -37,10 +37,13 @@ impl Config {
         let home = dirs::home_dir().ok_or(ConfigError::HomeDirNotFound)?;
         let path = home.join(".config").join("gfold.toml");
         let entry_config = match fs::read_to_string(path) {
-            Ok(contents) => match contents.is_empty() {
-                true => EntryConfig::default(),
-                false => toml::from_str(&contents)?,
-            },
+            Ok(contents) => {
+                if contents.is_empty() {
+                    EntryConfig::default()
+                } else {
+                    toml::from_str(&contents)?
+                }
+            }
             Err(e) => match e.kind() {
                 io::ErrorKind::NotFound => EntryConfig::default(),
                 _ => return Err(e.into()),

--- a/bin/gfold/src/display.rs
+++ b/bin/gfold/src/display.rs
@@ -64,17 +64,14 @@ impl DisplayHarness {
             all_reports.sort_by(|a, b| a.status.as_str().cmp(b.status.as_str()));
         }
 
-        let color_harness = ColorHarness::new(&color_mode);
+        let color_harness = ColorHarness::new(color_mode);
 
         for report in all_reports {
             color_harness.write_bold(&report.name, false)?;
 
-            let parent = match report.parent {
-                Some(s) => s,
-                None => {
-                    warn!("parent is empty for collector: {}", report.name);
-                    continue;
-                }
+            let Some(parent) = report.parent else {
+                warn!("parent is empty for collector: {}", report.name);
+                continue;
             };
             let full_path = Path::new(&parent).join(&report.name);
             let full_path_formatted = format!(
@@ -86,7 +83,7 @@ impl DisplayHarness {
             color_harness.write_gray(&full_path_formatted, true)?;
 
             print!("  ");
-            color_harness.write_status(&report.status, PAD)?;
+            color_harness.write_status(report.status, PAD)?;
             println!(" ({})", report.branch);
             if let Some(url) = &report.url {
                 println!("  {url}");
@@ -114,18 +111,17 @@ impl DisplayHarness {
     /// Display [`RepositoryCollection`] to `stdout` in the classic format.
     fn classic(reports: &RepositoryCollection, color_mode: ColorMode) -> io::Result<()> {
         debug!("detected classic display mode");
-        let color_harness = ColorHarness::new(&color_mode);
+        let color_harness = ColorHarness::new(color_mode);
 
         let length = reports.keys().len();
         let mut first = true;
         for (title, group) in reports {
             // FIXME(nick): make group title matching less cumbersome.
             if length > 1 {
-                match first {
-                    true => {
-                        first = false;
-                    }
-                    false => println!(),
+                if first {
+                    first = false;
+                } else {
+                    println!();
                 }
                 color_harness.write_bold(
                     match &title {
@@ -158,7 +154,7 @@ impl DisplayHarness {
 
             for report in reports {
                 print!("{:<path_width$}", report.name, path_width = name_max + PAD);
-                color_harness.write_status(&report.status, status_max + PAD)?;
+                color_harness.write_status(report.status, status_max + PAD)?;
                 println!(
                     "{:<branch_width$}{}",
                     report.branch,

--- a/bin/gfold/src/display/color.rs
+++ b/bin/gfold/src/display/color.rs
@@ -14,7 +14,7 @@ pub struct ColorHarness {
 }
 
 impl ColorHarness {
-    pub fn new(color_mode: &ColorMode) -> Self {
+    pub fn new(color_mode: ColorMode) -> Self {
         Self {
             color_choice: match &color_mode {
                 ColorMode::Always => ColorChoice::Always,
@@ -25,7 +25,7 @@ impl ColorHarness {
     }
 
     /// Writes the [`Status`] of the Git repository to `stdout`.
-    pub fn write_status(&self, status: &Status, status_width: usize) -> io::Result<()> {
+    pub fn write_status(&self, status: Status, status_width: usize) -> io::Result<()> {
         let mut stdout = StandardStream::stdout(self.color_choice);
         stdout.set_color(ColorSpec::new().set_fg(Some(match status {
             Status::Bare | Status::Unknown => Color::Red,
@@ -68,9 +68,10 @@ impl ColorHarness {
     ) -> io::Result<()> {
         let mut stdout = StandardStream::stdout(self.color_choice);
         stdout.set_color(color_spec)?;
-        match newline {
-            true => writeln!(&mut stdout, "{input}")?,
-            false => write!(&mut stdout, "{input}")?,
+        if newline {
+            writeln!(&mut stdout, "{input}")?;
+        } else {
+            write!(&mut stdout, "{input}")?;
         }
         stdout.reset()
     }

--- a/bin/gfold/src/main.rs
+++ b/bin/gfold/src/main.rs
@@ -19,9 +19,10 @@ mod display;
 /// the [`CliHarness`] to generate a [`Config`](config::Config). Then, this calls
 /// [`CliHarness::run()`].
 fn main() -> anyhow::Result<()> {
-    match env::var("RUST_LOG").is_err() {
-        true => Builder::new().filter_level(LevelFilter::Off).init(),
-        false => env_logger::init(),
+    if env::var("RUST_LOG").is_err() {
+        Builder::new().filter_level(LevelFilter::Off).init()
+    } else {
+        env_logger::init()
     }
     debug!("initialized logger");
 

--- a/bin/gfold/src/main.rs
+++ b/bin/gfold/src/main.rs
@@ -20,9 +20,9 @@ mod display;
 /// [`CliHarness::run()`].
 fn main() -> anyhow::Result<()> {
     if env::var("RUST_LOG").is_err() {
-        Builder::new().filter_level(LevelFilter::Off).init()
+        Builder::new().filter_level(LevelFilter::Off).init();
     } else {
-        env_logger::init()
+        env_logger::init();
     }
     debug!("initialized logger");
 


### PR DESCRIPTION
This PR refactors some of the CLI related logic. Uses Clap's ValueEnum instead of manually handling the enums as strings as throwing errors and all that - this makes the code more readable, and improves the help text.

**Before**:
```
Options:
  -c, --color-mode <COLOR_MODE>      specify color mode (options: ["always", "compatibility", "never"])
  -d, --display-mode <DISPLAY_MODE>  specify display format (options: ["standard", "standard-alphabetical", "json", "classic", "default"])
      --dry-run                      display finalized config options and exit (merged options from an optional config file and command line arguments)
  -i, --ignore-config-file           ignore config file settings
  -h, --help                         Print help
  -V, --version                      Print version
```

**After**:
```
Options:
  -c, --color-mode <COLOR_MODE>
          Possible values:
          - always:        Attempt to display colors as intended (default behavior)
          - compatibility: Display colors using widely-compatible methods at the potential expense of colors being displayed as intended
          - never:         Never display colors

  -d, --display-mode <DISPLAY_MODE>
          Possible values:
          - classic:               Informs the caller to display results in the classic format
          - json:                  Informs the caller to display results in JSON format
          - standard:              Informs the caller to display results in the standard (default) format. All results are sorted alphabetically and then sorted by status
          - standard-alphabetical: Informs the caller to display results in the standard (default) format with a twist: all results are solely sorted alphabetically (i.e. no additional sort by status)

      --dry-run
          display finalized config options and exit (merged options from an optional config file and command line arguments)

  -i, --ignore-config-file
          ignore config file settings

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```

We could possibly improve this a little bit further by using `#[clap(default...)]` (https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes) and have Clap fancily format the ValueEnum options into showing the defaults, but that gets complicated with the config file. Maybe another time :D

---

This PR also removes multiple instances of `match` on boolean values, replacing them with `if`, and resolves several other Clippy suggestions/fixes.