### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,12 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
 jobs:
   ci:
-    name: "Post Merge Checks" 
+    name: "Post Merge Checks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: xtask
-          args: ci
+      - run: cargo xtask ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,12 @@ jobs:
             artifact_name: gfold
             asset_name: gfold-darwin-amd64
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - run: cargo build --release --locked
-      - if: runner.os != 'Windows'
+      - shell: bash
         run: |
           if [ $(echo ${{ github.ref }} | grep "rc") ]; then
             echo "PRERELEASE=true" >> $GITHUB_ENV
@@ -38,31 +36,9 @@ jobs:
           fi
           echo $PRERELEASE
 
-          VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\///g')
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION=$VERSION"
-      - if: runner.os == 'Windows'
-        shell: powershell
-        run: |
-          $full = "${{ github.ref }}"
-
-          if ( $full -like '*rc*' ) {
-            echo "PRERELEASE=true" >> $env:GITHUB_ENV
-            echo "PRERELEASE=true"
-          } else {
-            echo "PRERELEASE=false" >> $env:GITHUB_ENV
-            echo "PRERELEASE=false"
-          }
-
-          $trimmed = $full -replace 'refs/tags/',''
-          echo "VERSION=$trimmed" >> $env:GITHUB_ENV
-          echo "VERSION=$trimmed"
-      - uses: svenstaro/upload-release-action@v2
+          mv target/release/${{ matrix.artifact_name }} ${{ matrix.asset_name }}
+      - uses: softprops/action-gh-release@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/release/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
-          tag: ${{ github.ref }}
+          files: ${{ matrix.asset_name }}
           prerelease: ${{ env.PRERELEASE }}
-          release_name: "gfold ${{ env.VERSION }}"
           body: "Please refer to **[CHANGELOG.md](https://github.com/nickgerace/gfold/blob/main/CHANGELOG.md)** for information on this release."


### PR DESCRIPTION
Closes #258. Switches from the archived [`actions-rs/toolchain@v1`](https://github.com/actions-rs/toolchain) to https://github.com/dtolnay/rust-toolchain, bumps `actions/checkout` version.

`ci.yml`: removes [unnecessary](https://github.com/dtolnay/rust-toolchain/issues/117) `Swatinem/rust-cache` action, runs `cargo xtask ci` directly instead of through `actions-rs/cargo` action (why was this necessary?).

`release.yml`: runs prerelease detection on all runners in bash shell instead of duplicating the script in bash and powershell, switches from [`svenstaro/upload-release-action@v2`](https://github.com/svenstaro/upload-release-action) to https://github.com/softprops/action-gh-release, removes the version parsing/handling logic (`softprops/action-gh-release` handles this for you, though with this change release names will no longer be prefixed with "gfold ").

