### PR TITLE
Split args into their own module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "cc"

--- a/justfile
+++ b/justfile
@@ -5,6 +5,10 @@ _default:
 run:
     cargo run -- -vvv ..
 
+# Build and run with the help flag
+run-help:
+    cargo run -- -h
+
 # Scan for potential bloat
 bloat:
     cargo bloat --release

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,38 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+
+use crate::config::{ColorMode, DisplayMode};
+
+const HELP: &str = "\
+More information: https://github.com/nickgerace/gfold
+
+Description: this application helps you keep track of multiple Git repositories via CLI. By default, it displays relevant information for all repos in the current working directory.
+
+Config file usage: while CLI options are prioritized, default options will fallback to the config file if it exists. Here are the config file lookup locations:
+
+    $XDG_CONFIG_HOME/gfold.toml
+    $XDG_CONFIG_HOME/gfold/config.toml
+    $HOME/.config/gfold.toml (or {{FOLDERID_Profile}}\\.config\\gfold.toml on Windows)";
+
+#[derive(Debug, Parser)]
+#[command(version, about = HELP, long_about = None)]
+pub struct Cli {
+    /// Specify path(s) to target directories (defaults to current working directory)
+    pub paths: Option<Vec<PathBuf>>,
+    /// Configure the color settings
+    #[arg(short, long)]
+    pub color_mode: Option<ColorMode>,
+    /// Configure how collected information is displayed
+    #[arg(short, long)]
+    pub display_mode: Option<DisplayMode>,
+    /// Display finalized config options and exit (merged options from an optional config file and command line arguments)
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Ignore config file settings
+    #[arg(short, long)]
+    pub ignore_config_file: bool,
+    #[command(flatten)]
+    pub verbose: Verbosity<InfoLevel>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,53 +30,21 @@
 use std::{env, path::PathBuf};
 
 use anyhow::Result;
+use args::Cli;
 use clap::Parser;
-use clap_verbosity_flag::{InfoLevel, Verbosity};
 use collector::RepositoryCollector;
 use log::debug;
 
-use crate::config::{ColorMode, Config, DisplayMode};
+use crate::config::{Config, DisplayMode};
 use crate::display::DisplayHarness;
 
+// TODO(nick): investigate module visibility.
+pub mod args;
 pub mod collector;
-pub mod repository_view;
-pub mod status;
-// TODO(nick): make this module private.
 pub mod config;
 pub mod display;
-
-const HELP: &str = "\
-More information: https://github.com/nickgerace/gfold
-
-Description: this application helps you keep track of multiple Git repositories via CLI. By default, it displays relevant information for all repos in the current working directory.
-
-Config File Usage: while CLI options are prioritized, default options will fallback to the config file if it exists. Here are the config file lookup locations:
-
-    $XDG_CONFIG_HOME/gfold.toml
-    $XDG_CONFIG_HOME/gfold/config.toml
-    $HOME/.config/gfold.toml (or {{FOLDERID_Profile}}\\.config\\gfold.toml on Windows)";
-
-#[derive(Parser)]
-#[command(version, about = HELP, long_about = None)]
-struct Cli {
-    /// specify path to target directory (defaults to current working directory)
-    pub paths: Option<Vec<PathBuf>>,
-
-    #[arg(short, long)]
-    pub color_mode: Option<ColorMode>,
-    #[arg(short, long)]
-    pub display_mode: Option<DisplayMode>,
-
-    /// display finalized config options and exit (merged options from an optional config file and command line arguments)
-    #[arg(long)]
-    pub dry_run: bool,
-    /// ignore config file settings
-    #[arg(short, long)]
-    pub ignore_config_file: bool,
-
-    #[command(flatten)]
-    verbose: Verbosity<InfoLevel>,
-}
+pub mod repository_view;
+pub mod status;
 
 /// Initializes the logger based on the debug flag and `RUST_LOG` environment variable, then
 /// parses CLI arguments and generates a [`Config`] by merging configurations as needed,


### PR DESCRIPTION
- Split arguments into their own module
- Streamline argument help message formatting
- Add "run-help" recipe